### PR TITLE
Fixed deprecation warning in Jupyter 4 caused by importing from IPython.kernel

### DIFF
--- a/octave_kernel.py
+++ b/octave_kernel.py
@@ -166,5 +166,8 @@ class OctaveKernel(ProcessMetaKernel):
             super(OctaveKernel, self).do_execute_direct(cmd.replace('\n', ''))
 
 if __name__ == '__main__':
-    from IPython.kernel.zmq.kernelapp import IPKernelApp
+    try:
+        from ipykernel.kernelapp import IPKernelApp
+    except ImportError:
+        from IPython.kernel.zmq.kernelapp import IPKernelApp
     IPKernelApp.launch_instance(kernel_class=OctaveKernel)


### PR DESCRIPTION
Patch attempts to import from the ipykernel module instead of IPython.kernel.zmq. This settles a ShimWarning in Jupyter 4.
If this new import fails, it will fallback to previous behavior.