### PR TITLE
Also use OCTAVE_EXECUTABLE in banner property if available

### DIFF
--- a/octave_kernel.py
+++ b/octave_kernel.py
@@ -38,7 +38,8 @@ class OctaveKernel(ProcessMetaKernel):
     @property
     def banner(self):
         if self._banner is None:
-            banner = subprocess.check_output(['octave', '--version'])
+            executable = os.environ.get('OCTAVE_EXECUTABLE', 'octave')
+            banner = subprocess.check_output([executable, '--version'])
             self._banner = banner.decode('utf-8')
         return self._banner
 


### PR DESCRIPTION
Also fix `FileNotFoundError` when Octave is not on the PATH but using OCTAVE_EXECUTABLE environment variable.

Before that change I get the following exception when starting an Octave notebook:

```
[IPKernelApp] ERROR | Exception in message handler:
Traceback (most recent call last):
  File "C:\Python34\lib\site-packages\ipykernel\kernelbase.py", line 212, in dispatch_shell
    handler(stream, idents, msg)
  File "C:\Python34\lib\site-packages\ipykernel\kernelbase.py", line 478, in kernel_info_request
    self.kernel_info, parent, ident)
  File "C:\Python34\lib\site-packages\ipykernel\kernelbase.py", line 472, in kernel_info
    'banner': self.banner,
  File "C:\Python34\lib\site-packages\octave_kernel.py", line 41, in banner
    banner = subprocess.check_output(['octave', '--version'])
  File "C:\Python34\lib\subprocess.py", line 607, in check_output
    with Popen(*popenargs, stdout=PIPE, **kwargs) as process:
  File "C:\Python34\lib\subprocess.py", line 859, in __init__
    restore_signals, start_new_session)
  File "C:\Python34\lib\subprocess.py", line 1112, in _execute_child
    startupinfo)
FileNotFoundError: [WinError 2] Das System kann die angegebene Datei nicht finden
```