### PR TITLE
Plot images at their native resolution, without any resizing

### DIFF
--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -192,10 +192,18 @@ class OctaveKernel(ProcessMetaKernel):
         res = self.plot_settings['resolution']
         cmd = """
         _figHandles = get(0, 'children');
-        for _fig=1:length(_figHandles);
+        for _fig=1:length(_figHandles),
             _handle = _figHandles(_fig);
-            _filename = fullfile('%(plot_dir)s', ['OctaveFig', sprintf('%%03d', _fig)]);
-            print(_handle, [_filename, '.%(fmt)s'], '-r%(res)s');
+            _filename = fullfile('%(plot_dir)s', ['OctaveFig', sprintf('%%03d.%(fmt)s', _fig)]);
+            try,
+               _image = double(get(get(get(_handle,'children'),'children'),'cdata'));
+               _clim = get(get(_handle,'children'),'clim');
+               _image = _image - _clim(1);
+               _image = _image ./ (_clim(2) - _clim(1));
+               imwrite(uint8(_image*255), _filename);
+            catch,
+               print(_handle, _filename, '-r%(res)s');
+            end,
             close(_handle);
         end;
         """ % locals()


### PR DESCRIPTION
Reason: when you are working with images, you usually want to see the result exactly as you have computed it, not resized or otherwise messed up with.

With this, whatever you want to display using imshow will appear in the notebook at the same resolution as the original image, without any resizing.

Image data is scaled, so the display range parameter works as expected. It's always saved as 8-bit, to keep things simple (didn't see any reason not to).

Limitations:

- huge images are not downsized, so they will slow down (and maybe lock up) the browser
- colormaps, axes, other annotations will not work, so you may want to make this optional
- I doubt SVG will work (not tested), but I'm not sure what to do about it

Test notebook [here](https://dl.dropboxusercontent.com/u/4124919/bleeding-edge/octave_kernel/octave-kernel-image-tests.html).

Another example notebook [here](https://dl.dropboxusercontent.com/u/4124919/bleeding-edge/stripefix/stripe-fix-h264.html) (I wrote this patch while doing that experiment => now you can see a possible use case for this feature)

That's it.
