### PR TITLE
Override input again

### DIFF
--- a/octave_kernel/@input/input.m
+++ b/octave_kernel/@input/input.m
@@ -1,0 +1,44 @@
+## -*- texinfo -*-
+## @deftypefn  {Built-in Function} {@var{ans} =} input (@var{prompt})
+## @deftypefnx {Built-in Function} {@var{ans} =} input (@var{prompt}, "s")
+## Print @var{prompt} and wait for user input.
+## 
+## For example,
+## 
+## @example
+## input ("Pick a number, any number! ")
+## @end example
+## 
+## @noindent
+## prints the prompt
+## 
+## @example
+## Pick a number, any number!
+## @end example
+## 
+## @noindent
+## and waits for the user to enter a value.  The string entered by the user
+## is evaluated as an expression, so it may be a literal constant, a variable
+## name, or any other valid Octave code.
+## 
+## The number of return arguments, their size, and their class depend on the
+## expression entered.
+## 
+## If you are only interested in getting a literal string value, you can call
+## @code{input} with the character string @qcode{"s"} as the second argument.
+## This tells Octave to return the string entered by the user directly, without
+## evaluating it first.
+## 
+## Because there may be output waiting to be displayed by the pager, it is a
+## good idea to always call @code{fflush (stdout)} before calling @code{input}.
+##  This will ensure that all pending output is written to the screen before
+## your prompt.
+## @seealso{yes_or_no, kbhit, pause, menu, listdlg}
+## @end deftypefn
+
+function ans = input(varargin)
+    if (nargin > 0)
+        varargin{1} = strcat(varargin{1}, '__stdin_prompt>');
+    end
+    ans = builtin('input', varargin{:});
+endfunction;

--- a/octave_kernel/@yes_or_no/yes_or_no.m
+++ b/octave_kernel/@yes_or_no/yes_or_no.m
@@ -1,0 +1,37 @@
+## -*- texinfo -*-
+## @deftypefn {Built-in Function} {@var{ans} =} yes_or_no ("@var{prompt}")
+## Ask the user a yes-or-no question. 
+##
+## Return logical true if the answer is yes or false if the answer is no.
+## 
+## Takes one argument, @var{prompt}, which is the string to display when asking
+## the question.  @var{prompt} should end in a space; @code{yes-or-no} adds the
+## string @samp{(yes or no) } to it.  The user must confirm the answer with
+## @key{RET} and can edit it until it has been confirmed.
+## @seealso{input}
+## @end deftypefn
+
+function ans = yes_or_no(varargin)
+  if (nargin == 0)
+    varargin = '';
+  end
+  if (nargin > 1)
+    builtin('yes_or_no', varargin{:});
+
+  else
+    prompt = strcat(varargin{1}, ' (yes_or_no) __stdin_prompt>');
+    while (1)
+      resp = input(prompt, 's');
+      if (strcmp(resp, 'yes') == 1)
+        ans = true;
+        break;
+
+      elseif (strcmp(resp, 'no') == 1)
+        ans = false;
+        break;
+
+      end;
+    end;
+  end;
+
+end;

--- a/octave_kernel/@yes_or_no/yes_or_no.m
+++ b/octave_kernel/@yes_or_no/yes_or_no.m
@@ -13,7 +13,7 @@
 
 function ans = yes_or_no(varargin)
   if (nargin == 0)
-    varargin = '';
+    varargin = {''};
   end
   if (nargin > 1)
     builtin('yes_or_no', varargin{:});
@@ -31,6 +31,7 @@ function ans = yes_or_no(varargin)
         break;
 
       end;
+      prompt = 'Please answer yes or no.';
     end;
   end;
 

--- a/octave_kernel/_input_hook.m
+++ b/octave_kernel/_input_hook.m
@@ -1,5 +1,0 @@
-function _input_hook()
-    %% Meant to be used as `add_input_event_hook(@_input_hook)`
-    %% to notify a remote caller of a stdin request.
-    disp('__stdin_prompt>');
-endfunction


### PR DESCRIPTION
- Fixes `input`, `pause`, `keyboard`, and `yes_or_no` on Windows.  `menu` is not working because streaming output does not work on Windows.
- Fixes completion (it was getting stdin_prompts).

Since we are no longer using the `input_event_hook`, we can only intercept a standard `keyboard` call with no arguments.

Fixes #65.