### PR TITLE
Adds texinfo to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ To install via conda::
 
     conda config --add channels conda-forge 
     conda install octave_kernel
+    conda install texinfo # For the inline documentation (shift-tab) to appear.
 
 To use it, run one of:
 


### PR DESCRIPTION
* Adds conda install texinfo for the inline documentation text to appear without errors.

I feel the functionality of octave kernel in the Jupyter Notebook without the inline documentation is a big flaw I suggest this should be installed along side octave_kernel
I am on Ubuntu 16.04.
Not sure if the inline documentation works on other systems without needing texinfo.