### PR TITLE
Add Binder files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 An Octave kernel for Jupyter
 ============================
 
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/Calysto/octave_kernel/master?filepath=octave_kernel.ipynb
+
 Prerequisites
 -------------
 `Jupyter Notebook <http://jupyter.readthedocs.org/en/latest/install.html>`_ and GNU Octave_.

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,8 @@
+name: octave-kernel
+channels:
+- conda-forge
+dependencies:
+- gnuplot
+- octave_kernel
+- texinfo
+

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - gnuplot
+- octave
 - octave_kernel
 - texinfo
 


### PR DESCRIPTION
To be able to quickly try the kernel on Binder:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/octave_kernel/binder?filepath=octave_kernel.ipynb)

However it seems like it's timing out on start:

![image](https://user-images.githubusercontent.com/591645/82116296-02a5c500-9769-11ea-9502-1f053b2af5d8.png)

Could this be related to `octave-cli` not being found?

```bash
jovyan@jupyter-jtpio-2doctave-5fkernel-2dfu7ned5t:~$ python -m octave_kernel.check
Octave kernel v0.31.1
Metakernel v0.24.4
Python v3.7.6 | packaged by conda-forge | (default, Jan  7 2020, 22:33:48)
[GCC 7.3.0]
Python path: /srv/conda/envs/notebook/bin/python

Connecting to Octave...
Octave connection established
octave-cli not found, please see README
```