### PR TITLE
Fix error: '_make_figures' undefined near line 1, column 1

### DIFF
--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -273,6 +273,8 @@ class OctaveEngine(object):
             self.eval('drawnow("expose");')
             if not plot_dir:
                 return
+        if not self._has_startup:
+            self._startup()
         fmt = settings['format']
         res = settings['resolution']
         wid = settings['width']


### PR DESCRIPTION
Because the [octave_kernel](https://github.com/Calysto/octave_kernel) path is not added to the octave path.

call stacks
1. OctaveKernel.run_as_main()
2. do_execute_direct
3. make_figures

```txt
inline plot failed, consider trying another graphics toolkit
error: '_make_figures' undefined near line 1, column 1
```