### PR TITLE
Add flatpak support for Octave auto-detection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,29 @@ jobs:
     - name: Run test on macos
       run: just test
 
+  test-flatpak:
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v6
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+    - name: Install just
+      uses: extractions/setup-just@v2
+    - name: Install flatpak and octave via flatpak
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y flatpak dbus-x11
+        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        sudo flatpak install -y --noninteractive flathub org.octave.Octave
+    - name: Install dependencies
+      run: just install
+    - name: Run test with flatpak octave
+      run: |
+        uv run python -m octave_kernel.check
+        dbus-run-session -- xvfb-run --auto-servernum just test
+
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest

--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -524,7 +524,16 @@ class OctaveEngine(object):
             executable = which("octave-cli")
             if not executable:
                 executable = which("octave")
-                if not executable:
+            if not executable:
+                # Try flatpak as a fallback.
+                try:
+                    subprocess.check_call(
+                        ["flatpak", "info", "org.octave.Octave"],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    executable = "flatpak run org.octave.Octave --no-gui"
+                except (subprocess.CalledProcessError, FileNotFoundError):
                     raise OSError("octave not found, please see README")
         return executable.replace(os.path.sep, "/")
 


### PR DESCRIPTION
## Summary

- `_get_executable` now falls back to `flatpak run org.octave.Octave --no-gui` when `octave-cli` and `octave` are not found on `PATH`, using `flatpak info org.octave.Octave` to confirm availability before using it
- Adds a `test-flatpak` CI job that installs `org.octave.Octave` from Flathub instead of via `apt`, exercising the new auto-detection path end-to-end

## Test plan

- [x] Existing `test-linux` and `test-macos` jobs still pass (no change to their behavior)
- [x] New `test-flatpak` job installs Octave via Flathub and runs the full test suite using the flatpak fallback path