### PR TITLE
Add tests_check job for branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,3 +139,21 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+
+  tests_check: # This job does nothing and is only used for the branch protection
+    if: always()
+    needs:
+      - test-linux
+      - test-macos
+      - test-flatpak
+      - make_sdist
+      - test_sdist
+      - static
+      - check_release
+      - link_check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- Adds a `tests_check` job to the CI workflow that depends on all other jobs
- Intended for use as a single branch protection status check