### PR TITLE
Move test dependencies to dependency-groups

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ default:
 
 install:
     uv tool run prek install
-    uv sync --extra test
+    uv sync --group test
 
 docker-build:
     docker build --rm --force-rm -t calysto/octave-notebook:latest .
@@ -17,13 +17,13 @@ docker-run:
     docker run -it --rm -p {{PORT}}:8888 calysto/octave-notebook
 
 test:
-    uv sync --extra test
+    uv sync --group test
     uv run python -m unittest -v test_octave_kernel.py
     uv run python -m octave_kernel.check
     uv run python test_octave_kernel.py
 
 test-notebook:
-    uv run --extra test jupyter nbconvert --to notebook --execute --ExecutePreprocessor.kernel_name=octave --ExecutePreprocessor.timeout=60 --stdout octave_kernel.ipynb > /dev/null
+    uv run --group test jupyter nbconvert --to notebook --execute --ExecutePreprocessor.kernel_name=octave --ExecutePreprocessor.timeout=60 --stdout octave_kernel.ipynb > /dev/null
 
 pre-commit *args="":
     uv tool run prek --all-files {{args}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 file = "README.rst"
 content-type = "text/x-rst"
 
-[project.optional-dependencies]
+[dependency-groups]
 test = ["pytest", "nbconvert", "jupyter_kernel_test"]
 
 # Used to call hatch_build.py

--- a/uv.lock
+++ b/uv.lock
@@ -636,7 +636,7 @@ dependencies = [
     { name = "metakernel" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 test = [
     { name = "jupyter-kernel-test" },
     { name = "nbconvert" },
@@ -647,12 +647,15 @@ test = [
 requires-dist = [
     { name = "ipykernel" },
     { name = "jupyter-client", specifier = ">=4.3.0" },
-    { name = "jupyter-kernel-test", marker = "extra == 'test'" },
     { name = "metakernel", specifier = ">=0.24.0" },
-    { name = "nbconvert", marker = "extra == 'test'" },
-    { name = "pytest", marker = "extra == 'test'" },
 ]
-provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+test = [
+    { name = "jupyter-kernel-test" },
+    { name = "nbconvert" },
+    { name = "pytest" },
+]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary
- Replaces `[project.optional-dependencies]` with `[dependency-groups]` in `pyproject.toml` (PEP 735 / uv native dependency groups)
- Updates all `--extra test` flags to `--group test` in `justfile`