### PR TITLE
Add composite GitHub Action for Octave installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,9 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v4
     - name: Install octave
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y octave gnuplot
+      uses: ./
+      with:
+        install-type: ubuntu
     - name: Install just
       uses: extractions/setup-just@v2
     - name: Install dependencies
@@ -59,7 +59,9 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@v2
     - name: Install octave
-      run: brew install octave
+      uses: ./
+      with:
+        install-type: macos
     - name: Run test on macos
       run: just test
 
@@ -74,13 +76,9 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@v2
     - name: Install octave
-      run: choco install octave --no-progress -y
-    - name: Add octave to PATH
-      shell: bash
-      run: |
-        octave_bin=$(find "/c/Program Files/GNU Octave" -type f -name "octave.exe" | head -1)
-        octave_bin=$(dirname "$octave_bin")
-        echo "$octave_bin" >> "$GITHUB_PATH"
+      uses: ./
+      with:
+        install-type: windows
     - name: Run test on windows
       run: just test
 
@@ -94,12 +92,10 @@ jobs:
       uses: astral-sh/setup-uv@v4
     - name: Install just
       uses: extractions/setup-just@v2
-    - name: Install flatpak and octave via flatpak
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y flatpak dbus-x11
-        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install -y --noninteractive flathub org.octave.Octave
+    - name: Install octave
+      uses: ./
+      with:
+        install-type: ubuntu-flatpak
     - name: Install dependencies
       run: just install
     - name: Run test with flatpak octave

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,44 @@
+name: Install Octave
+description: Installs Octave for the given platform type.
+
+inputs:
+  install-type:
+    description: 'Platform install type: ubuntu, macos, windows, or ubuntu-flatpak'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install octave (ubuntu)
+      if: inputs.install-type == 'ubuntu'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y octave gnuplot
+
+    - name: Install octave (macos)
+      if: inputs.install-type == 'macos'
+      shell: bash
+      run: brew install octave
+
+    - name: Install octave (windows)
+      if: inputs.install-type == 'windows'
+      shell: bash
+      run: choco install octave --no-progress -y
+
+    - name: Add octave to PATH (windows)
+      if: inputs.install-type == 'windows'
+      shell: bash
+      run: |
+        octave_bin=$(find "/c/Program Files/GNU Octave" -type f -name "octave.exe" | head -1)
+        octave_bin=$(dirname "$octave_bin")
+        echo "$octave_bin" >> "$GITHUB_PATH"
+
+    - name: Install flatpak and octave via flatpak (ubuntu-flatpak)
+      if: inputs.install-type == 'ubuntu-flatpak'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y flatpak dbus-x11
+        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        sudo flatpak install -y --noninteractive flathub org.octave.Octave


### PR DESCRIPTION
## Summary

- Extracts platform-specific Octave install logic into a reusable composite action (`action.yml`) at the repo root
- Accepts an `install-type` input with values `ubuntu`, `macos`, `windows`, and `ubuntu-flatpak`
- Updates `test.yml` to use `uses: ./` with the appropriate `install-type` for each test job

## Test plan

- [x] Verify `test-linux`, `test-macos`, `test-windows`, and `test-flatpak` CI jobs pass with the refactored workflow
- [x] Confirm no behavioral change — install steps are identical to the previous inline commands