### PR TITLE
Test Python 3.10 on ubuntu-22.04 in test-linux matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,14 @@ permissions:
 
 jobs:
   test-linux:
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        os: [ubuntu-latest]
+        python-version: ['3.11', '3.12', '3.13', '3.14', '3.14t']
+        include:
+          - os: ubuntu-22.04
+            python-version: '3.10'
       fail-fast: false
 
     steps:


### PR DESCRIPTION
## Summary
- Adds `os` as a matrix parameter to the `test-linux` job
- Adds `ubuntu-22.04` via a matrix `include` to test Python 3.10 against an older Octave version
- Removes Python 3.10 from the `ubuntu-latest` matrix so it only runs on `ubuntu-22.04`