### PR TITLE
Add run-notebook justfile target

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,5 +35,8 @@ cover *args="":
 typing:
     uv run --group typing mypy . --install-types --non-interactive
 
+run-notebook:
+    uv run --with notebook jupyter notebook octave_kernel.ipynb
+
 pre-commit *args="":
     uv tool run prek --all-files {{args}}


### PR DESCRIPTION
## Summary
- Adds a `run-notebook` recipe to the justfile that launches `octave_kernel.ipynb` via `jupyter notebook`

## Test plan
- [x] Run `just run-notebook` and verify the notebook opens in the browser