### PR TITLE
Add debugging instructions for the kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ python -m octave_kernel.check
 
 ## Troubleshooting
 
+### Debugging the Kernel
+
+To see detailed Jupyter protocol messages and kernel log output, launch an interactive console session with debug logging:
+
+```shell
+pip install jupyter-console
+jupyter console --log-level=debug --kernel=octave
+```
+
+`jupyter-console` is not installed by default and must be installed separately. This is useful for diagnosing communication issues between Jupyter and the kernel.
+
 ### Kernel Times Out While Starting
 
 If the kernel does not start, run the following command from a terminal:


### PR DESCRIPTION
## Summary

- Adds a new "Debugging the Kernel" subsection to the Troubleshooting section in the README
- Documents the `jupyter console --log-level=debug --kernel=octave` command for diagnosing communication issues
- Notes that `jupyter-console` must be installed separately

## Test plan

- [x] Verify the documentation renders correctly on the MkDocs site