### PR TITLE
Tear down kernel after each test in OctaveKernelTests

### DIFF
--- a/test_octave_kernel.py
+++ b/test_octave_kernel.py
@@ -10,11 +10,24 @@ from octave_kernel._utils import is_sandboxed_octave
 
 
 class OctaveKernelTests(jkt.KernelTests):  # type:ignore[misc]
+    kernel_name = "octave"
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        pass  # Kernel is started per-test in setUp instead.
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        pass  # Kernel is stopped per-test in tearDown instead.
+
     def setUp(self) -> None:
+        self.km, self.kc = jkt.start_new_kernel(kernel_name=self.kernel_name)
         # Make sure any initial output is emitted (for example toolkit warnings).
         self.execute_helper(self.code_hello_world)
 
-    kernel_name = "octave"
+    def tearDown(self) -> None:
+        self.kc.stop_channels()
+        self.km.shutdown_kernel()
 
     language_name = "octave"
 


### PR DESCRIPTION
## Summary

- Override `setUp`/`tearDown` in `OctaveKernelTests` to start and stop a fresh Octave kernel per test
- No-op `setUpClass`/`tearDownClass` to disable the inherited class-level kernel lifecycle
- Ensures Octave instances are always cleaned up after each test rather than persisting for the full suite

## Test plan

- [x] Run `just test-kernel` to confirm the existing tests pass with the new per-test lifecycle