### PR TITLE
Fix input() prompt garbled when called inside a for-loop

### DIFF
--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -205,15 +205,32 @@ class OctaveKernel(ProcessMetaKernel):
         Parameters
         ----------
         text
-            Prompt text shown to the user.
+            Prompt text shown to the user, as received from pexpect.  When
+            ``input()`` is called inside a loop, pexpect may bundle output
+            from the previous iteration together with the next prompt in a
+            single string.  This method extracts and streams any such
+            preceding output so it appears in the cell, then forwards only
+            the actual prompt text to the Jupyter client (issue #179).
 
         Returns
         -------
         str
             The user's input string.
         """
-        # Remove the stdin prompt to restore the original prompt.
+        # Remove the stdin prompt marker to restore the original prompt.
         text = text.replace(STDIN_PROMPT, "")
+
+        # When input() is called in a loop, pexpect may deliver output from the
+        # previous iteration concatenated before the next prompt.  Split it off,
+        # stream it so it appears in the cell output, and keep only the prompt.
+        for sep in ("\r\n", "\n", "\r"):
+            if sep in text:
+                preceding, text = text.rsplit(sep, 1)
+                preceding = preceding.rstrip("\r")
+                if preceding:
+                    self.Print(preceding)
+                break
+
         return super().raw_input(text)  # type: ignore[no-untyped-call, no-any-return]
 
     def get_completions(self, info: dict[str, Any]) -> list[str]:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -828,3 +828,44 @@ class TestPauseFromFunction:
             "stdin_handler was not called — pause() from a function did not "
             "produce a visible prompt (issue #194)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #179 — input() in a for-loop only prompts on the first iteration
+# ---------------------------------------------------------------------------
+
+
+class TestInputInLoop:
+    """Regression tests for issue #179.
+
+    When ``input()`` is called inside a for-loop, the pexpect buffer may
+    deliver output from the previous iteration concatenated with the next
+    prompt as a single string.  The kernel must call stdin_handler on every
+    iteration, not just the first one.
+    """
+
+    @_skip_if_sandboxed
+    def test_input_in_loop_calls_stdin_handler_each_iteration(self, engine):
+        """input() in a for-loop must invoke stdin_handler on every iteration (issue #179)."""
+        iterations = 3
+        stdin_calls: list[str] = []
+
+        def fake_stdin(prompt: str) -> str:
+            stdin_calls.append(prompt)
+            return str(len(stdin_calls))
+
+        old_stdin = engine.stdin_handler
+        engine.stdin_handler = fake_stdin
+        try:
+            engine.eval(
+                f"for i=1:{iterations}\n  s = input('Enter: ', 's');\n  disp(s);\nend",
+                timeout=15,
+            )
+        finally:
+            engine.stdin_handler = old_stdin
+
+        assert len(stdin_calls) == iterations, (
+            f"stdin_handler was called {len(stdin_calls)} time(s), expected "
+            f"{iterations}.  input() in a for-loop did not prompt on every "
+            "iteration (issue #179)."
+        )

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -411,6 +411,37 @@ class TestRawInput:
             result = kernel.raw_input("Enter: ")
         assert result == "42"
 
+    def test_strips_preceding_output_from_prompt_in_loop(self, kernel):
+        """raw_input strips preceding output when input() is called in a loop (issue #179).
+
+        When input() is used in a for-loop, pexpect may deliver output from
+        the previous iteration concatenated with the next prompt as a single
+        string.  raw_input must strip that leading output so the Jupyter client
+        sees only the intended prompt text.
+        """
+        received: list[Any] = []
+
+        def capture(self, text):
+            received.append(text)
+            return "user_input"
+
+        kernel.Print = MagicMock()
+        with patch.object(ProcessMetaKernel, "raw_input", capture):
+            kernel.raw_input("1\r\nEnter: " + STDIN_PROMPT)
+        assert received == ["Enter: "]
+
+    def test_preceding_output_is_streamed_not_lost(self, kernel):
+        """raw_input streams preceding output so it appears in the cell (issue #179)."""
+        printed: list[Any] = []
+
+        def capture_print(*args: Any, **kwargs: Any) -> None:
+            printed.extend(args)
+
+        kernel.Print = capture_print
+        with patch.object(ProcessMetaKernel, "raw_input", lambda self, t: "x"):
+            kernel.raw_input("1\r\nEnter: " + STDIN_PROMPT)
+        assert any("1" in str(s) for s in printed)
+
 
 # ---------------------------------------------------------------------------
 # get_completions


### PR DESCRIPTION
Closes #179.

## Summary

- When `input()` is used in a `for`-loop, pexpect bundles output from the previous iteration together with the next prompt in a single string (e.g. `"1\r\nEnter:__stdin_prompt>"`). `raw_input` only stripped the `STDIN_PROMPT` marker, so the Jupyter client received the garbled string `"1\r\nEnter:"` as the prompt — causing the input box to appear invisible or broken after the first iteration.
- Fix `OctaveKernel.raw_input` to split off any preceding output at the last newline, stream it via `self.Print()` so it appears in the cell output, and forward only the actual prompt text to `super().raw_input()`.

## Test plan

- [x] `tests/test_kernel.py::TestRawInput::test_strips_preceding_output_from_prompt_in_loop` — unit test verifying the prompt forwarded to Jupyter is clean (was failing before this fix)
- [x] `tests/test_kernel.py::TestRawInput::test_preceding_output_is_streamed_not_lost` — verifies preceding output is streamed rather than silently dropped
- [x] `tests/test_engine.py::TestInputInLoop::test_input_in_loop_calls_stdin_handler_each_iteration` — integration regression test verifying `stdin_handler` fires on every loop iteration
- [x] `just test` — all 160 tests pass
- [x] `just test-kernel` — all integration tests pass