### PR TITLE
Use importlib.resources to load kernel.json

### DIFF
--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
+from importlib.resources import files
 from typing import Any
 from xml.dom import minidom
 
@@ -51,11 +52,12 @@ class PDF:
 
 def get_kernel_json() -> dict[str, Any]:
     """Get the kernel json for the kernel."""
-    here = os.path.dirname(__file__)
-    default_json_file = os.path.join(here, "kernel.json")
-    json_file = os.environ.get("OCTAVE_KERNEL_JSON", default_json_file)
-    with open(json_file) as fid:
-        data = json.load(fid)
+    json_file = os.environ.get("OCTAVE_KERNEL_JSON")
+    if json_file:
+        with open(json_file) as fid:
+            data = json.load(fid)
+    else:
+        data = json.loads(files("octave_kernel").joinpath("kernel.json").read_text())
     data["argv"][0] = sys.executable
     return data  # type: ignore[no-any-return]
 


### PR DESCRIPTION
## Summary

- Closes #165
- Replaces `os.path.dirname(__file__)` with `importlib.resources.files()` to locate `kernel.json` at runtime
- Fixes `FileNotFoundError` when `octave_kernel` is imported inside a PyInstaller-bundled application, where `__file__` points to a temp directory that doesn't contain data files

## Test plan

- [x] Verified the original failure is reproducible by simulating a PyInstaller temp directory (no `kernel.json` adjacent to `__file__`)
- [x] Verified `get_kernel_json()` succeeds after the fix even when `__file__` points to a directory without `kernel.json`
- [x] All 160 existing tests pass (`just test`)