### PR TITLE
Allow benchmark job to be skipped in tests_check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,4 +235,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
+          allowed-skips: benchmark
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- The `benchmark` job only runs on `pull_request` events, so it is skipped on `push` and `schedule` triggers
- Added `allowed-skips: benchmark` to the `alls-green` step so `tests_check` branch protection passes when `benchmark` is skipped