### PR TITLE
Fix codecov.yml: move after_n_builds to codecov.notify

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,16 +4,18 @@ coverage:
       default:
         target: 95%
         threshold: 0%
-        # Wait for all 10 coverage uploads before reporting:
-        # 6 test-linux (5x ubuntu-latest + 1x ubuntu-22.04) +
-        # 2 test-other-systems (macos + windows) +
-        # 2 test-other-ubuntu (flatpak + snap)
-        after_n_builds: 10
     patch:
       default:
         target: 95%
         threshold: 0%
-        after_n_builds: 10
+
+codecov:
+  notify:
+    # Wait for all 10 coverage uploads before reporting:
+    # 6 test-linux (5x ubuntu-latest + 1x ubuntu-22.04) +
+    # 2 test-other-systems (macos + windows) +
+    # 2 test-other-ubuntu (flatpak + snap)
+    after_n_builds: 10
 
 comment:
   layout: "reach,diff,flags,files"


### PR DESCRIPTION
## Summary
- `after_n_builds` is not a valid field under `coverage.status.project` or `coverage.status.patch`
- Moved it to `codecov.notify.after_n_builds` per the Codecov schema
- Validated with `curl --data-binary @codecov.yml https://codecov.io/validate`