### PR TITLE
Add load_octaverc trait to skip sourcing ~/.octaverc on startup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,8 @@ Configuration
 -------------
 The kernel can be configured by adding an ``octave_kernel_config.py`` file to the
 ``jupyter`` config path.  The ``OctaveKernel`` class offers ``plot_settings``, ``inline_toolkit``,
-``kernel_json``, and ``cli_options`` as configurable traits.  The available plot settings are:
-'format', 'backend', 'width', 'height', 'resolution', and 'plot_dir'.
+``kernel_json``, ``cli_options``, and ``load_octaverc`` as configurable traits.  The available plot
+settings are: 'format', 'backend', 'width', 'height', 'resolution', and 'plot_dir'.
 
 .. code:: bash
 
@@ -76,6 +76,17 @@ The inline toolkit is the ``graphics_toolkit`` used to generate plots for the in
 backend.  It will default to whatever backend ``octave`` defaults to.
 The different backend can be used for inline plotting either by using this configuration
 or by using the plot magic and putting the backend name after ``inline:``, e.g. ``plot -b inline:fltk``.
+
+By default the kernel sources ``~/.octaverc`` at startup (after disabling the pager with
+``more off``).  Set ``load_octaverc = False`` to skip this step.  This is useful in
+reproducible or sandboxed environments—such as CI pipelines or shared JupyterHub
+deployments—where the user's init file may modify the path, set conflicting options, print
+output that confuses the kernel, or simply does not exist.
+
+.. code:: python
+
+    # ~/.jupyter/octave_kernel_config.py
+    c.OctaveKernel.load_octaverc = False
 
 Supported Platforms
 -------------------

--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -21,7 +21,7 @@ from xml.dom import minidom
 
 from IPython.display import SVG, Image
 from metakernel import MetaKernel, ProcessMetaKernel, REPLWrapper, u
-from traitlets import Dict, Unicode
+from traitlets import Bool, Dict, Unicode
 
 from ._utils import get_octave_executable, is_sandboxed_octave
 from ._version import __version__
@@ -70,7 +70,7 @@ class OctaveKernel(ProcessMetaKernel):
 
     Configuration is done via ``octave_kernel_config.py`` in the Jupyter config
     path. Configurable traits: ``plot_settings``, ``inline_toolkit``,
-    ``kernel_json``, ``cli_options``, and ``executable``.
+    ``kernel_json``, ``cli_options``, ``executable``, and ``load_octaverc``.
     """
 
     app_name = "octave_kernel"
@@ -82,6 +82,7 @@ class OctaveKernel(ProcessMetaKernel):
     cli_options = Unicode("").tag(config=True)
     inline_toolkit = Unicode("").tag(config=True)
     executable = Unicode("").tag(config=True)
+    load_octaverc = Bool(True).tag(config=True)
 
     _octave_engine: OctaveEngine | None = None
     _language_version: str | None = None
@@ -117,6 +118,7 @@ class OctaveKernel(ProcessMetaKernel):
             stream_handler=self.Print,
             cli_options=self.cli_options,
             inline_toolkit=self.inline_toolkit,
+            load_octaverc=self.load_octaverc,
             logger=self.log,
             executable=self.executable,
         )
@@ -295,6 +297,7 @@ class OctaveEngine:
         defer_startup: bool = False,
         cli_options: str = "",
         executable: str = "",
+        load_octaverc: bool = True,
         logger: Any = None,
     ) -> None:
         """Initialize the Octave engine.
@@ -323,6 +326,11 @@ class OctaveEngine:
             Path to the Octave executable. Resolved in order: this argument,
             ``OCTAVE_EXECUTABLE`` env var, ``octave``/``octave-cli`` on
             ``PATH``, then Flatpak.
+        load_octaverc
+            If True (default), source ``~/.octaverc`` during startup.  Set to
+            False to skip loading the user init file, which is useful in
+            reproducible or sandboxed environments where the init file may
+            alter the path, set conflicting options, or is simply unavailable.
         logger
             Logger instance; defaults to the module-level logger.
         """
@@ -335,6 +343,7 @@ class OctaveEngine:
         self.tmp_dir = self._get_temp_dir()
         self.cli_options = cli_options
         self.inline_toolkit = inline_toolkit
+        self.load_octaverc = load_octaverc
         self.repl = self._create_repl()
         self.error_handler = error_handler
         self.stream_handler = stream_handler
@@ -529,7 +538,8 @@ class OctaveEngine:
         """Start up the Octave process."""
         self._has_startup = True
         cwd = os.getcwd().replace(os.path.sep, "/")
-        cmd = f'more off; source ~/.octaverc; cd("{cwd}");{self.repl.prompt_change_cmd}'
+        octaverc = "source ~/.octaverc; " if self.load_octaverc else ""
+        cmd = f'more off; {octaverc}cd("{cwd}");{self.repl.prompt_change_cmd}'
         self.eval(cmd, silent=True)
         here = os.path.realpath(os.path.dirname(__file__)).replace(os.path.sep, "/")
         self.eval(f'addpath("{here}")')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,8 @@ strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 exclude = [
-    "hatch_build.*\\.py"
+    "hatch_build.*\\.py",
+    "env/"
 ]
 
 [[tool.mypy.overrides]]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -365,6 +365,17 @@ class TestStartup:
         assert mock_engine._plot_settings is not None
         assert "backend" in mock_engine._plot_settings
 
+    def test_sources_octaverc_by_default(self, mock_engine):
+        mock_eval = self._run_startup(mock_engine)
+        first_call_code = mock_eval.call_args_list[0][0][0]
+        assert "source ~/.octaverc" in first_call_code
+
+    def test_skips_octaverc_when_load_octaverc_false(self, mock_engine):
+        mock_engine.load_octaverc = False
+        mock_eval = self._run_startup(mock_engine)
+        first_call_code = mock_eval.call_args_list[0][0][0]
+        assert "source ~/.octaverc" not in first_call_code
+
 
 # ---------------------------------------------------------------------------
 # _handle_svg


### PR DESCRIPTION
## Summary

- Adds a `load_octaverc` configurable `Bool` trait to `OctaveKernel` (default `True`) and a matching `load_octaverc` parameter to `OctaveEngine`
- When set to `False`, the kernel skips `source ~/.octaverc` during startup — useful for reproducible/sandboxed environments (CI, shared JupyterHub) where the init file may modify the path, print output that confuses the kernel, or is unavailable
- Fixes a pre-existing mypy error caused by the ASV `env/` directory containing a duplicate `benchmarks` module, by adding `env/` to mypy's `exclude` list
- Adds unit tests verifying `source ~/.octaverc` is present by default and absent when `load_octaverc=False`

## Test plan

- [x] All existing tests pass (`just test`)
- [x] Type check passes (`just typing`)
- [x] New tests cover default and disabled behaviour (`TestStartup`)
- [x] Verify `c.OctaveKernel.load_octaverc = False` in `~/.jupyter/octave_kernel_config.py` prevents `~/.octaverc` from being sourced