### PR TITLE
Add S (flake8-bandit) ruff checks

### DIFF
--- a/octave_kernel/_utils.py
+++ b/octave_kernel/_utils.py
@@ -37,7 +37,7 @@ def get_octave_executable(executable: str = "") -> str:
             # Try flatpak as a fallback.
             try:
                 subprocess.check_call(
-                    ["flatpak", "info", "org.octave.Octave"],
+                    ["flatpak", "info", "org.octave.Octave"],  # noqa: S607
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )

--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -468,7 +468,7 @@ class OctaveEngine:
             The plot directory containing the files.
         """
         settings = self._plot_settings
-        assert settings is not None
+        assert settings is not None  # noqa: S101
         if not settings["backend"].startswith("inline"):
             self.eval('drawnow("expose");')
             if not plot_dir:
@@ -553,7 +553,7 @@ class OctaveEngine:
         im = SVG(data=data)  # type: ignore[no-untyped-call]
         try:
             im.data = self._fix_svg_size(im.data)
-        except Exception:
+        except Exception:  # noqa: S110
             pass
         return im
 
@@ -564,7 +564,7 @@ class OctaveEngine:
         """
         # Minidom does not support parseUnicode, so it must be decoded
         # to accept unicode characters
-        parsed = minidom.parseString(data.encode("utf-8"))
+        parsed = minidom.parseString(data.encode("utf-8"))  # noqa: S318
         (svg,) = parsed.getElementsByTagName("svg")
 
         viewbox = svg.getAttribute("viewBox").split(" ")
@@ -673,7 +673,7 @@ class OctaveEngine:
         """Validate the Octave executable."""
         cmd = shlex.split(f"{executable} --eval 'disp(version)'")
         try:
-            return subprocess.check_output(cmd, text=True).strip()
+            return subprocess.check_output(cmd, text=True).strip()  # noqa: S603
         except subprocess.CalledProcessError as e:
             if "OCTAVE_EXECUTABLE" in os.environ:
                 prefix = f"OCTAVE_EXECUTABLE ({executable})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,13 @@ extend-select = [
   "B",      # flake8-bugbear
   "I",      # isort
   "RUF",    # Ruff-specific
+  "S",      # flake8-bandit
   "UP",     # pyupgrade
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "S107", "S108", "S607"]
+"test_*.py" = ["S101", "S107", "S108", "S607"]
 
 [tool.check-wheel-contents]
 ignore = ["W002"]


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Enables the `S` (flake8-bandit) rule set in ruff to add security linting.

## Changes

- Add `"S"` to `extend-select` in `[tool.ruff.lint]`
- Add `[tool.ruff.lint.per-file-ignores]` to suppress `S101` (assert), `S108` (tmp path strings in mock values), and `S607` (partial executable path) in test files
- Add targeted `# noqa` comments for intentional patterns in production code:
  - `S101` on a type-narrowing `assert` in `kernel.py`
  - `S110` on an intentional silent `except: pass` for SVG fixing
  - `S318` on `minidom.parseString` parsing our own generated SVG output
  - `S603` on a `subprocess` call with a controlled executable path
  - `S607` on `"flatpak"` intentionally resolved via PATH

## Backwards-incompatible changes

None

## Testing

`just pre-commit` passes with all hooks green.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)