### PR TITLE
Add validate-pyproject hook and lint justfile target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,11 @@ repos:
         args: ["-L", "ect,ans"]
         exclude: '\.ipynb$'
 
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+      - id: validate-pyproject
+
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: "v1.10.0"
     hooks:

--- a/justfile
+++ b/justfile
@@ -38,6 +38,9 @@ typing:
 run-notebook:
     uv run --with notebook --with ./ jupyter notebook octave_kernel.ipynb
 
+lint:
+    uv tool run prek run validate-pyproject ruff-format ruff-check --all-files
+
 pre-commit *args="":
     uv tool run prek --all-files {{args}}
 


### PR DESCRIPTION
## References

N/A

## Description

Adds `abravalheri/validate-pyproject` as a pre-commit hook to validate `pyproject.toml` on every commit, and introduces a `just lint` target for quickly running the ruff and validate-pyproject hooks without running the full pre-commit suite.

## Changes

- Add `abravalheri/validate-pyproject` v0.25 to `.pre-commit-config.yaml`
- Add `just lint` target running `validate-pyproject`, `ruff-format`, and `ruff-check` via pre-commit

## Backwards-incompatible changes

None

## Testing

Ran `just lint` — all hooks passed.

## AI usage

- [x] AI tools were used to generate parts of this PR
- [x] The human author has reviewed the AI-generated content

Tools: Claude Sonnet 4.6 (Claude Code)