### PR TITLE
chore: pre-commit maintenance updates

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 9 * * 1'  # Every Monday at 9am
 
+permissions:
+  pull-requests: write
+
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
@@ -15,7 +18,7 @@ jobs:
           python-version: '3.x'
       - run: pip install pre-commit
       - run: pre-commit autoupdate
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6
         with:
           commit-message: 'chore: pre-commit autoupdate'
           title: 'chore: pre-commit autoupdate'

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,22 @@
+# .github/workflows/pre-commit-autoupdate.yml
+name: Pre-commit autoupdate
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9am
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install pre-commit
+      - run: pre-commit autoupdate
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'chore: pre-commit autoupdate'
+          title: 'chore: pre-commit autoupdate'
+          branch: pre-commit-autoupdate

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -13,10 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-          cache: false
+          cache: pip
       - run: pip install pre-commit
       - run: pre-commit autoupdate
       - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          cache: false
       - run: pip install pre-commit
       - run: pre-commit autoupdate
       - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,8 @@ repos:
     rev: v0.25
     hooks:
       - id: validate-pyproject
+        # Optional extra validations from SchemaStore:
+        additional_dependencies: ["validate-pyproject-schema-store[all]"]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: "v1.10.0"


### PR DESCRIPTION
## References

N/A

## Description

Two pre-commit maintenance improvements:
- Add a weekly GitHub Actions workflow to automatically run `pre-commit autoupdate` and open a PR with the results
- Add `validate-pyproject-schema-store[all]` as an additional dependency for the `validate-pyproject` hook to enable extra validations from SchemaStore

## Changes

- Add `.github/workflows/pre-commit-autoupdate.yml`: scheduled workflow (Mondays at 9am) that runs `pre-commit autoupdate` and opens a PR via `peter-evans/create-pull-request`
- Update `.pre-commit-config.yaml`: add `validate-pyproject-schema-store[all]` to the `validate-pyproject` hook

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] AI tools were used in creating this PR
- [x] The human author has reviewed and understands all AI-generated contributions

Tools: Claude Sonnet 4.6 (Claude Code)