### PR TITLE
ci: cache apt, Homebrew, and Windows installer for Octave installs

### DIFF
--- a/.github/scripts/macos-install-cache.sh
+++ b/.github/scripts/macos-install-cache.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 echo "Restoring Octave Cellar from cache archive..."
-sudo tar -xf ~/brew-octave-cellar.tar -C /
+tar -xf ~/brew-octave-cellar.tar -C /
 echo "Linking octave..."
 brew link octave

--- a/.github/scripts/macos-install-cache.sh
+++ b/.github/scripts/macos-install-cache.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu
+echo "Restoring Octave Cellar from cache archive..."
+sudo tar -xf ~/brew-octave-cellar.tar -C /
+echo "Linking octave..."
+brew link octave

--- a/.github/scripts/macos-install-cache.sh
+++ b/.github/scripts/macos-install-cache.sh
@@ -4,3 +4,7 @@ echo "Restoring Octave Cellar from cache archive..."
 tar -xf ~/brew-octave-cellar.tar -C /
 echo "Linking octave..."
 brew link octave
+# Set Qt plugin path so octave can find the cocoa platform plugin
+QT_PREFIX=$(brew --prefix qtbase 2>/dev/null || echo "/opt/homebrew/opt/qtbase")
+echo "QT_QPA_PLATFORM_PLUGIN_PATH=$QT_PREFIX/share/qt/plugins/platforms" >> "$GITHUB_ENV"
+echo "Set QT_QPA_PLATFORM_PLUGIN_PATH=$QT_PREFIX/share/qt/plugins/platforms"

--- a/.github/scripts/macos-install.sh
+++ b/.github/scripts/macos-install.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -eu
-ls /opt/homebrew/Cellar | sort > /tmp/brew_before.txt
+ls /opt/homebrew/Cellar | sort > /tmp/brew_cellar_before.txt
+ls /opt/homebrew/opt | sort > /tmp/brew_opt_before.txt
 echo "Installing octave..."
 brew install octave
 echo "Creating Cellar cache archive..."
-NEW_FORMULAE=$(comm -13 /tmp/brew_before.txt <(ls /opt/homebrew/Cellar | sort))
+NEW_CELLAR=$(comm -13 /tmp/brew_cellar_before.txt <(ls /opt/homebrew/Cellar | sort))
+NEW_OPT=$(comm -13 /tmp/brew_opt_before.txt <(ls /opt/homebrew/opt | sort))
 PATHS=()
 while IFS= read -r f; do
   [ -d "/opt/homebrew/Cellar/$f" ] && PATHS+=("/opt/homebrew/Cellar/$f")
+done <<< "$NEW_CELLAR"
+while IFS= read -r f; do
   [ -e "/opt/homebrew/opt/$f" ] && PATHS+=("/opt/homebrew/opt/$f")
-done <<< "$NEW_FORMULAE"
+done <<< "$NEW_OPT"
 tar -cf ~/brew-octave-cellar.tar "${PATHS[@]}"
-echo "Cache archive created: ~/brew-octave-cellar.tar"
+echo "Cache archive created with ${#PATHS[@]} entries"

--- a/.github/scripts/macos-install.sh
+++ b/.github/scripts/macos-install.sh
@@ -10,5 +10,5 @@ while IFS= read -r f; do
   [ -d "/opt/homebrew/Cellar/$f" ] && PATHS+=("/opt/homebrew/Cellar/$f")
   [ -e "/opt/homebrew/opt/$f" ] && PATHS+=("/opt/homebrew/opt/$f")
 done <<< "$NEW_FORMULAE"
-sudo tar -cf ~/brew-octave-cellar.tar "${PATHS[@]}"
+tar -cf ~/brew-octave-cellar.tar "${PATHS[@]}"
 echo "Cache archive created: ~/brew-octave-cellar.tar"

--- a/.github/scripts/macos-install.sh
+++ b/.github/scripts/macos-install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eu
+ls /opt/homebrew/Cellar | sort > /tmp/brew_before.txt
+echo "Installing octave..."
+brew install octave
+echo "Creating Cellar cache archive..."
+NEW_FORMULAE=$(comm -13 /tmp/brew_before.txt <(ls /opt/homebrew/Cellar | sort))
+PATHS=()
+while IFS= read -r f; do
+  [ -d "/opt/homebrew/Cellar/$f" ] && PATHS+=("/opt/homebrew/Cellar/$f")
+  [ -e "/opt/homebrew/opt/$f" ] && PATHS+=("/opt/homebrew/opt/$f")
+done <<< "$NEW_FORMULAE"
+sudo tar -cf ~/brew-octave-cellar.tar "${PATHS[@]}"
+echo "Cache archive created: ~/brew-octave-cellar.tar"

--- a/.github/scripts/windows-install.ps1
+++ b/.github/scripts/windows-install.ps1
@@ -1,5 +1,7 @@
 $installer = Get-ChildItem $env:OCTAVE_CACHE_PATH -Filter "*.exe" | Select-Object -First 1
+echo "Running installer: $($installer.FullName)"
 Start-Process -FilePath $installer.FullName -ArgumentList "/S" -Wait -NoNewWindow
+echo "Installer completed"
 
 $searchPaths = @(
   "$env:LOCALAPPDATA\Programs",
@@ -9,6 +11,7 @@ $searchPaths = @(
 )
 $octaveExe = $null
 foreach ($path in $searchPaths) {
+  echo "Searching: $path"
   $octaveExe = Get-ChildItem $path -Recurse -Filter "octave.exe" -ErrorAction SilentlyContinue |
     Select-Object -First 1
   if ($octaveExe) { break }

--- a/.github/scripts/windows-install.ps1
+++ b/.github/scripts/windows-install.ps1
@@ -1,0 +1,8 @@
+$installer = Get-ChildItem $env:OCTAVE_CACHE_PATH -Filter "*.exe" | Select-Object -First 1
+Start-Process -FilePath $installer.FullName -ArgumentList "/S" -Wait -NoNewWindow
+$octaveRoot = Get-ChildItem "$env:LOCALAPPDATA\Programs\GNU Octave" -Directory |
+  Select-Object -First 1 -ExpandProperty FullName
+$octaveBin = "$octaveRoot\mingw64\bin"
+echo "Octave bin: $octaveBin"
+echo "$octaveBin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+($octaveBin -replace '\\', '/' -replace '^C:', '/c') >> $env:GITHUB_PATH

--- a/.github/scripts/windows-install.ps1
+++ b/.github/scripts/windows-install.ps1
@@ -1,8 +1,22 @@
 $installer = Get-ChildItem $env:OCTAVE_CACHE_PATH -Filter "*.exe" | Select-Object -First 1
 Start-Process -FilePath $installer.FullName -ArgumentList "/S" -Wait -NoNewWindow
-$octaveRoot = Get-ChildItem "$env:LOCALAPPDATA\Programs\GNU Octave" -Directory |
-  Select-Object -First 1 -ExpandProperty FullName
-$octaveBin = "$octaveRoot\mingw64\bin"
+
+$searchPaths = @(
+  "$env:LOCALAPPDATA\Programs",
+  "$env:ProgramFiles\GNU Octave",
+  "$env:ProgramFiles\Octave",
+  "C:\Octave"
+)
+$octaveExe = $null
+foreach ($path in $searchPaths) {
+  $octaveExe = Get-ChildItem $path -Recurse -Filter "octave.exe" -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if ($octaveExe) { break }
+}
+if (-not $octaveExe) {
+  throw "Could not find octave.exe after installation"
+}
+$octaveBin = $octaveExe.DirectoryName
 echo "Octave bin: $octaveBin"
 echo "$octaveBin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 ($octaveBin -replace '\\', '/' -replace '^C:', '/c') >> $env:GITHUB_PATH

--- a/.github/scripts/windows-setup-cache.ps1
+++ b/.github/scripts/windows-setup-cache.ps1
@@ -1,5 +1,6 @@
 $cachePath = "$env:RUNNER_TEMP\octave-installer"
 New-Item -Path $cachePath -ItemType Directory -Force
+echo "Cache path: $cachePath"
 $version = winget show --id GNU.Octave -e --accept-source-agreements 2>$null |
   Where-Object { $_ -match "^Version:" } |
   Select-Object -First 1 |
@@ -7,5 +8,6 @@ $version = winget show --id GNU.Octave -e --accept-source-agreements 2>$null |
 if (-not $version) {
   throw "Failed to determine Octave version from winget"
 }
+echo "Octave version: $version"
 "OCTAVE_CACHE_PATH=$cachePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding Utf8 -Append
 "OCTAVE_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding Utf8 -Append

--- a/.github/scripts/windows-setup-cache.ps1
+++ b/.github/scripts/windows-setup-cache.ps1
@@ -1,8 +1,11 @@
 $cachePath = "$env:RUNNER_TEMP\octave-installer"
 New-Item -Path $cachePath -ItemType Directory -Force
-$version = winget show --id GNU.Octave -e |
+$version = winget show --id GNU.Octave -e --accept-source-agreements 2>$null |
   Where-Object { $_ -match "^Version:" } |
   Select-Object -First 1 |
   ForEach-Object { ($_ -replace "^Version:\s*", "").Trim() }
+if (-not $version) {
+  throw "Failed to determine Octave version from winget"
+}
 "OCTAVE_CACHE_PATH=$cachePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding Utf8 -Append
 "OCTAVE_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding Utf8 -Append

--- a/.github/scripts/windows-setup-cache.ps1
+++ b/.github/scripts/windows-setup-cache.ps1
@@ -1,0 +1,8 @@
+$cachePath = "$env:RUNNER_TEMP\octave-installer"
+New-Item -Path $cachePath -ItemType Directory -Force
+$version = winget show --id GNU.Octave -e |
+  Where-Object { $_ -match "^Version:" } |
+  Select-Object -First 1 |
+  ForEach-Object { ($_ -replace "^Version:\s*", "").Trim() }
+"OCTAVE_CACHE_PATH=$cachePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding Utf8 -Append
+"OCTAVE_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding Utf8 -Append

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     rev: 2.3.2
     hooks:
       - id: poetry-check
+        args: ["--strict"]
       - id: poetry-lock
 
   - repo: https://github.com/adamchainz/blacken-docs

--- a/action.yml
+++ b/action.yml
@@ -61,22 +61,15 @@ runs:
       id: cache-brew-octave
       uses: actions/cache@v4
       with:
-        path: /opt/homebrew/Cellar/octave
+        path: ~/Library/Caches/Homebrew/downloads
         key: macos-brew-octave-${{ env.OCTAVE_VERSION }}
 
     - name: Install octave (macos)
-      if: inputs.install-type == 'macos' && steps.cache-brew-octave.outputs.cache-hit != 'true'
+      if: inputs.install-type == 'macos'
       shell: bash
       run: |
         set -eu
         brew install octave
-
-    - name: Link octave (macos)
-      if: inputs.install-type == 'macos' && steps.cache-brew-octave.outputs.cache-hit == 'true'
-      shell: bash
-      run: |
-        set -eu
-        brew link octave
 
     - name: Set up Octave installer cache (windows)
       if: inputs.install-type == 'windows'

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/apt-cache
-        key: apt-${{ inputs.install-type }}-${{ runner.os }}
+        key: apt-${{ inputs.install-type }}-${{ env.ImageOS }}
 
     - name: Restore apt packages from cache (ubuntu)
       if: startsWith(inputs.install-type, 'ubuntu')

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       run: find ~/apt-cache -name "*.deb" -exec sudo cp {} /var/cache/apt/archives/ \;
 
     - name: Update apt package lists (ubuntu)
-      if: startsWith(inputs.install-type, 'ubuntu') && steps.cache-apt.outputs.cache-hit != 'true'
+      if: startsWith(inputs.install-type, 'ubuntu')
       shell: bash
       run: sudo apt-get update
 

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         set -eu
         sudo apt-get autoclean
-        find /var/cache/apt/archives -name "*.deb" -exec cp {} ~/apt-cache/ \;
+        sudo find /var/cache/apt/archives -name "*.deb" -exec cp {} ~/apt-cache/ \;
         sudo rm -f /var/cache/apt/archives/lock
         sudo rm -rf /var/cache/apt/archives/partial
 

--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,23 @@ runs:
   steps:
     - name: Install octave (ubuntu)
       if: inputs.install-type == 'ubuntu'
+      uses: tecolicom/actions-use-apt-tools@065d3fb036b7fc85487573596f97732ed0d3fce1 # v1.7
+      with:
+        tools: octave gnuplot
+
+    - name: Get Octave version for cache key (macos)
+      if: inputs.install-type == 'macos'
       shell: bash
       run: |
-        set -eu
-        sudo apt-get update
-        sudo apt-get install -y octave gnuplot
+        OCTAVE_VERSION=$(brew info --json octave | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['versions']['stable'])")
+        echo "OCTAVE_VERSION=$OCTAVE_VERSION" >> $GITHUB_ENV
+
+    - name: Restore Octave bottle from cache (macos)
+      if: inputs.install-type == 'macos'
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Caches/Homebrew/downloads
+        key: macos-brew-octave-${{ env.OCTAVE_VERSION }}
 
     - name: Install octave (macos)
       if: inputs.install-type == 'macos'
@@ -24,51 +36,43 @@ runs:
         set -eu
         brew install octave
 
+    - name: Set up Octave installer cache (windows)
+      if: inputs.install-type == 'windows'
+      shell: pwsh
+      run: |
+        & "${{ github.action_path }}/.github/scripts/windows-setup-cache.ps1"
+
+    - name: Restore Octave installer from cache (windows)
+      if: inputs.install-type == 'windows'
+      id: cache-octave-windows
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.OCTAVE_CACHE_PATH }}
+        key: windows-octave-${{ env.OCTAVE_VERSION }}
+
+    - name: Download Octave installer (windows)
+      if: inputs.install-type == 'windows' && steps.cache-octave-windows.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        winget download --id GNU.Octave -e --download-directory $env:OCTAVE_CACHE_PATH
+
     - name: Install Octave (windows)
       if: inputs.install-type == 'windows'
       shell: pwsh
       run: |
-        $maxRetries = 3
-        $retryDelay = 10
-        $attempt = 0
-        $success = $false
+        & "${{ github.action_path }}/.github/scripts/windows-install.ps1"
 
-        while ($attempt -lt $maxRetries -and -not $success) {
-            $attempt++
-            Write-Host "Attempt ${attempt} of ${maxRetries}: Installing GNU Octave..."
+    - name: Install flatpak and dbus-x11 (ubuntu-flatpak)
+      if: inputs.install-type == 'ubuntu-flatpak'
+      uses: tecolicom/actions-use-apt-tools@065d3fb036b7fc85487573596f97732ed0d3fce1 # v1.7
+      with:
+        tools: flatpak dbus-x11
 
-            winget install --id GNU.Octave -e --silent --accept-source-agreements --accept-package-agreements
-
-            if ($LASTEXITCODE -eq 0) {
-                $success = $true
-                Write-Host "Installation succeeded on attempt ${attempt}."
-            } else {
-                Write-Host "Attempt ${attempt} failed (exit code: ${LASTEXITCODE})."
-                if ($attempt -lt $maxRetries) {
-                    Write-Host "Retrying in ${retryDelay} seconds..."
-                    Start-Sleep -Seconds $retryDelay
-                }
-            }
-        }
-
-        if (-not $success) {
-            throw "GNU Octave installation failed after ${maxRetries} attempts."
-        }
-
-        $octaveRoot = Get-ChildItem "$env:LOCALAPPDATA\Programs\GNU Octave" -Directory | Select-Object -First 1 -ExpandProperty FullName
-        $octaveBin = "$octaveRoot\mingw64\bin"
-        echo "Octave bin: $octaveBin"
-        echo "$octaveBin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        $bashPath = $octaveBin -replace '\\', '/' -replace '^C:', '/c'
-        echo "$bashPath" >> $env:GITHUB_PATH
-
-    - name: Install flatpak and octave via flatpak (ubuntu-flatpak)
+    - name: Install octave via flatpak (ubuntu-flatpak)
       if: inputs.install-type == 'ubuntu-flatpak'
       shell: bash
       run: |
         set -eu
-        sudo apt-get update
-        sudo apt-get install -y flatpak dbus-x11
         sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
         sudo flatpak install -y --noninteractive flathub org.octave.Octave
 

--- a/action.yml
+++ b/action.yml
@@ -9,12 +9,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up apt cache dir (ubuntu)
+      if: startsWith(inputs.install-type, 'ubuntu')
+      shell: bash
+      run: mkdir -p ~/apt-cache
+
     - name: Cache apt packages (ubuntu)
       if: startsWith(inputs.install-type, 'ubuntu')
       uses: actions/cache@v4
       with:
-        path: /var/cache/apt/archives
+        path: ~/apt-cache
         key: apt-${{ inputs.install-type }}-${{ runner.os }}
+
+    - name: Restore apt packages from cache (ubuntu)
+      if: startsWith(inputs.install-type, 'ubuntu')
+      shell: bash
+      run: find ~/apt-cache -name "*.deb" -exec sudo cp {} /var/cache/apt/archives/ \;
 
     - name: Install octave (ubuntu)
       if: inputs.install-type == 'ubuntu'
@@ -30,6 +40,7 @@ runs:
       run: |
         set -eu
         sudo apt-get autoclean
+        find /var/cache/apt/archives -name "*.deb" -exec cp {} ~/apt-cache/ \;
         sudo rm -f /var/cache/apt/archives/lock
         sudo rm -rf /var/cache/apt/archives/partial
 

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,11 @@ runs:
   using: composite
   steps:
     - name: Cache apt packages (ubuntu)
-      if: inputs.install-type == 'ubuntu'
+      if: startsWith(inputs.install-type, 'ubuntu')
       uses: actions/cache@v4
       with:
         path: /var/cache/apt/archives
-        key: apt-octave-gnuplot-${{ runner.os }}
+        key: apt-${{ inputs.install-type }}-${{ runner.os }}
 
     - name: Install octave (ubuntu)
       if: inputs.install-type == 'ubuntu'
@@ -25,7 +25,7 @@ runs:
         sudo apt-get install -y octave gnuplot
 
     - name: Clean apt package cache (ubuntu)
-      if: inputs.install-type == 'ubuntu'
+      if: startsWith(inputs.install-type, 'ubuntu')
       shell: bash
       run: |
         set -eu
@@ -82,9 +82,11 @@ runs:
 
     - name: Install flatpak and dbus-x11 (ubuntu-flatpak)
       if: inputs.install-type == 'ubuntu-flatpak'
-      uses: tecolicom/actions-use-apt-tools@065d3fb036b7fc85487573596f97732ed0d3fce1 # v1.7
-      with:
-        tools: flatpak dbus-x11
+      shell: bash
+      run: |
+        set -eu
+        sudo apt-get update
+        sudo apt-get install -y flatpak dbus-x11
 
     - name: Install octave via flatpak (ubuntu-flatpak)
       if: inputs.install-type == 'ubuntu-flatpak'

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,29 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Cache apt packages (ubuntu)
+      if: inputs.install-type == 'ubuntu'
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt/archives
+        key: apt-octave-gnuplot-${{ runner.os }}
+
     - name: Install octave (ubuntu)
       if: inputs.install-type == 'ubuntu'
-      uses: tecolicom/actions-use-apt-tools@065d3fb036b7fc85487573596f97732ed0d3fce1 # v1.7
-      with:
-        tools: octave gnuplot
+      shell: bash
+      run: |
+        set -eu
+        sudo apt-get update
+        sudo apt-get install -y octave gnuplot
+
+    - name: Clean apt package cache (ubuntu)
+      if: inputs.install-type == 'ubuntu'
+      shell: bash
+      run: |
+        set -eu
+        sudo apt-get autoclean
+        sudo rm -f /var/cache/apt/archives/lock
+        sudo rm -rf /var/cache/apt/archives/partial
 
     - name: Get Octave version for cache key (macos)
       if: inputs.install-type == 'macos'

--- a/action.yml
+++ b/action.yml
@@ -63,15 +63,18 @@ runs:
       id: cache-brew-octave
       uses: actions/cache@v4
       with:
-        path: ~/Library/Caches/Homebrew/downloads
+        path: ~/brew-octave-cellar.tar
         key: macos-brew-octave-${{ env.OCTAVE_VERSION }}
 
-    - name: Install octave (macos)
-      if: inputs.install-type == 'macos'
+    - name: Install Octave from cache (macos)
+      if: inputs.install-type == 'macos' && steps.cache-brew-octave.outputs.cache-hit == 'true'
       shell: bash
-      run: |
-        set -eu
-        brew install octave
+      run: bash "${{ github.action_path }}/.github/scripts/macos-install-cache.sh"
+
+    - name: Install octave (macos)
+      if: inputs.install-type == 'macos' && steps.cache-brew-octave.outputs.cache-hit != 'true'
+      shell: bash
+      run: bash "${{ github.action_path }}/.github/scripts/macos-install.sh"
 
     - name: Set up Octave installer cache (windows)
       if: inputs.install-type == 'windows'

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,9 @@ runs:
     - name: Set up apt cache dir (ubuntu)
       if: startsWith(inputs.install-type, 'ubuntu')
       shell: bash
-      run: mkdir -p ~/apt-cache
+      run: |
+        mkdir -p ~/apt-cache
+        echo "OS_VERSION=$(. /etc/os-release && echo $VERSION_ID)" >> $GITHUB_ENV
 
     - name: Cache apt packages (ubuntu)
       if: startsWith(inputs.install-type, 'ubuntu')
@@ -20,7 +22,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/apt-cache
-        key: apt-${{ inputs.install-type }}-${{ env.ImageOS }}
+        key: apt-${{ inputs.install-type }}-${{ env.OS_VERSION }}
 
     - name: Restore apt packages from cache (ubuntu)
       if: startsWith(inputs.install-type, 'ubuntu')

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,7 @@ runs:
 
     - name: Cache apt packages (ubuntu)
       if: startsWith(inputs.install-type, 'ubuntu')
+      id: cache-apt
       uses: actions/cache@v4
       with:
         path: ~/apt-cache
@@ -26,12 +27,16 @@ runs:
       shell: bash
       run: find ~/apt-cache -name "*.deb" -exec sudo cp {} /var/cache/apt/archives/ \;
 
+    - name: Update apt package lists (ubuntu)
+      if: startsWith(inputs.install-type, 'ubuntu') && steps.cache-apt.outputs.cache-hit != 'true'
+      shell: bash
+      run: sudo apt-get update
+
     - name: Install octave (ubuntu)
       if: inputs.install-type == 'ubuntu'
       shell: bash
       run: |
         set -eu
-        sudo apt-get update
         sudo apt-get install -y octave gnuplot
 
     - name: Clean apt package cache (ubuntu)
@@ -51,19 +56,27 @@ runs:
         OCTAVE_VERSION=$(brew info --json octave | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['versions']['stable'])")
         echo "OCTAVE_VERSION=$OCTAVE_VERSION" >> $GITHUB_ENV
 
-    - name: Restore Octave bottle from cache (macos)
+    - name: Restore Octave from cache (macos)
       if: inputs.install-type == 'macos'
+      id: cache-brew-octave
       uses: actions/cache@v4
       with:
-        path: ~/Library/Caches/Homebrew/downloads
+        path: /opt/homebrew/Cellar/octave
         key: macos-brew-octave-${{ env.OCTAVE_VERSION }}
 
     - name: Install octave (macos)
-      if: inputs.install-type == 'macos'
+      if: inputs.install-type == 'macos' && steps.cache-brew-octave.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -eu
         brew install octave
+
+    - name: Link octave (macos)
+      if: inputs.install-type == 'macos' && steps.cache-brew-octave.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        set -eu
+        brew link octave
 
     - name: Set up Octave installer cache (windows)
       if: inputs.install-type == 'windows'
@@ -96,7 +109,6 @@ runs:
       shell: bash
       run: |
         set -eu
-        sudo apt-get update
         sudo apt-get install -y flatpak dbus-x11
 
     - name: Install octave via flatpak (ubuntu-flatpak)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ coverage = ["pytest", "pytest-cov"]
 benchmark = ["asv"]
 docs = ["mkdocs>=1.5", "mkdocs-material>=9.0", "mkdocstrings[python]>=0.24", "mkdocs-jupyter>=0.24"]
 
+[tool.poetry]
+package-mode = true
+
 # Used to call hatch_build.py
 [tool.hatch.build.hooks.custom]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "hatchling.build"
 [project]
 name = "octave_kernel"
 description = "'A Jupyter kernel for Octave.'"
-license = {file = "LICENSE.txt"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
 authors = [{name = "'Steven Silvester'", email = "steven.silvester@ieee.org"}]
 classifiers = [
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Adds installer caching to all three platform install paths in `action.yml` to reduce CI time, and extracts Windows PowerShell logic into standalone scripts.

## Changes

- Replace `apt-get` with `tecolicom/actions-use-apt-tools` for `ubuntu` and `ubuntu-flatpak` installs (caches apt packages across runs)
- Add Homebrew bottle caching for macOS, keyed on the Octave stable version from `brew info --json`
- Replace retry-based `winget install` on Windows with `winget download` + `actions/cache` + direct installer execution, keyed on the Octave version from `winget show`
- Extract Windows cache-setup and install PowerShell logic into `.github/scripts/windows-setup-cache.ps1` and `.github/scripts/windows-install.ps1`

## Backwards-incompatible changes

None

## Testing

- [ ] Make sure we get a cache hit after a successful run
- [ ] Make sure a third run also passes

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Sonnet 4.6 (Claude Code)