### PR TITLE
ci: prevent cron jobs on forks and improve CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   analyze:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -10,11 +10,18 @@ permissions:
 
 jobs:
   autoupdate:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
@@ -23,6 +30,7 @@ jobs:
       - run: pre-commit autoupdate
       - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: pre-commit autoupdate'
           title: 'chore: pre-commit autoupdate'
           branch: pre-commit-autoupdate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   release:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -40,6 +41,7 @@ jobs:
 
   # Build the package from the release tag so the artifact matches what was released.
   build-package:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     name: Build & verify package
     needs: [release]
     runs-on: ubuntu-latest
@@ -56,6 +58,7 @@ jobs:
       - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
 
   publish-docker:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     needs: [release]
     runs-on: ubuntu-latest
     environment: release
@@ -90,6 +93,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   publish:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     needs: [build-package]
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   test-linux:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -52,6 +53,7 @@ jobs:
          poetry run python -m octave_kernel install --user
 
   test-other-systems:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
@@ -84,6 +86,7 @@ jobs:
         fail_ci_if_error: false
 
   test-other-ubuntu:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     strategy:
       matrix:
         install-type: [ubuntu-flatpak, ubuntu-snap]
@@ -106,6 +109,7 @@ jobs:
       run: just test-notebook
 
   cover-linux:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -127,6 +131,7 @@ jobs:
         fail_ci_if_error: false
 
   make_sdist:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     name: Build and Inspect Package
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -138,6 +143,7 @@ jobs:
       - uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
 
   test_sdist:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     runs-on: ubuntu-latest
     needs: [make_sdist]
     name: Install from SDist and Test
@@ -156,6 +162,7 @@ jobs:
           test_command: "jupyter kernelspec list | grep octave"
 
   static:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -166,7 +173,7 @@ jobs:
         run: just typing
 
   benchmark:
-    if: github.event_name == 'pull_request'
+    if: (github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel') && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -184,7 +191,25 @@ jobs:
     - name: Run benchmark comparison
       run: just benchmark-compare
 
+  test_release:
+    if: github.event_name == 'pull_request'
+    name: Test Release (Dry Run)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: calysto/maintainer_tools/actions/base-setup@v1
+      - uses: calysto/maintainer_tools/actions/release@v1
+        with:
+          version: patch
+          dry_run: "true"
+          ref: ${{ github.head_ref }}
+
   docker-build:
+    if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -207,7 +232,7 @@ jobs:
       run: just test-docker
 
   tests_check: # This job does nothing and is only used for the branch protection
-    if: always()
+    if: always() && (github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel')
     needs:
       - test-linux
       - test-other-systems
@@ -218,10 +243,11 @@ jobs:
       - static
       - benchmark
       - docker-build
+      - test_release
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
-          allowed-skips: benchmark
+          allowed-skips: benchmark,test_release
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## References

None

## Description

Prevent scheduled/cron CI workflows from running on forks, fix the pre-commit autoupdate workflow's push authentication, and add a test_release dry-run job.

## Changes

- Add fork guard (`github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'`) to all jobs in workflows with schedule triggers (test.yml, codeql.yml, release.yml, pre-commit-autoupdate.yml)
- Fix pre-commit-autoupdate workflow to use app token for pushing to protected branches
- Add `test_release` dry-run job to test workflow (PR-only, skippable in `tests_check`)

## Backwards-incompatible changes

None

## Testing

CI will validate the workflow syntax via actionlint. The test_release job will run as part of this PR.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (claude-opus-4-6)