### PR TITLE
ci: allow changelog_body input in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      changelog_body:
+        description: "Custom release notes (overrides auto-generated changelog). Use \\n for newlines, or trigger via 'gh workflow run' for real multiline input."
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "0 9 * * *"
 
@@ -41,6 +46,7 @@ jobs:
         with:
           version: ${{ github.event_name == 'schedule' && '10.10.10.10' || inputs.version }}
           dry_run: ${{ steps.dry-run.outputs.value }}
+          changelog_body: ${{ inputs.changelog_body }}
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           ref: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Adds an optional `changelog_body` workflow input to `release.yml`
- When provided, it overrides the auto-generated changelog in the release
- Passes the value through to `calysto/maintainer_tools/actions/release@v1`

## Usage
Trigger via `gh workflow run` for real multiline input, or use `\n` for newlines in the GitHub UI.