### PR TITLE
ci: skip GitHub release API call in nightly dry run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
           version: ${{ github.event_name == 'schedule' && '10.10.10.10' || inputs.version }}
           dry_run: ${{ steps.dry-run.outputs.value }}
           changelog_body: ${{ inputs.changelog_body }}
-          app_id: ${{ vars.APP_ID }}
-          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ github.event_name != 'schedule' && vars.APP_ID || '' }}
+          app_private_key: ${{ github.event_name != 'schedule' && secrets.APP_PRIVATE_KEY || '' }}
           ref: ${{ github.ref_name }}
 
   # Build the package from the release tag so the artifact matches what was released.


### PR DESCRIPTION
## Summary

- The nightly scheduled release workflow was failing because the `Create GitHub release` step in `calysto/maintainer_tools/actions/release@v1` calls `gh api ... --jq .id` to create a draft release, which returned an empty response — causing jq to error with `unexpected end of JSON input` and exit 1
- That step is gated on `if: inputs.app_id != ''`, so passing empty `app_id`/`app_private_key` for scheduled runs skips it entirely
- The nightly dry run still validates version bumps, changelog generation, and pre-commit hooks — the GitHub release API call is not meaningful to test in a dry run anyway

## Test plan

- [ ] Verify the next nightly run succeeds (or manually trigger the Release workflow with `dry_run: true`)