### PR TITLE
fix: inject --auto-servernum via executable property to fix xvfb-run on kernel restart

### DIFF
--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -338,7 +338,7 @@ class OctaveEngine:
             logger = logging.getLogger(__name__)
             logging.basicConfig()
         self.logger = logger
-        self.executable = self._get_executable(executable)
+        self._executable = self._get_executable(executable)
         self.version = self._validate_executable(self.executable)
         self.tmp_dir = self._get_temp_dir()
         self.cli_options = cli_options
@@ -665,22 +665,25 @@ class OctaveEngine:
                         self.stream_handler(line)
         return "\n".join(lines)
 
-    def _get_executable(self, executable: str = "") -> str:
-        """Find the best octave executable."""
-        return get_octave_executable(executable)
-
-    def _validate_executable(self, executable: str) -> str:
-        """Validate the Octave executable."""
-        parts = shlex.split(executable)
-        # When xvfb-run wraps octave, use --auto-servernum so validation
-        # doesn't conflict with an already-running Xvfb (e.g. on kernel restart).
+    @property
+    def executable(self) -> str:
+        """The Octave executable string, with --auto-servernum injected for xvfb-run."""
+        parts = shlex.split(self._executable)
         if (
             parts
             and os.path.basename(parts[0]) == "xvfb-run"
             and "--auto-servernum" not in parts
         ):
             parts.insert(1, "--auto-servernum")
-        cmd = [*parts, "--eval", "disp(version)"]
+        return shlex.join(parts)
+
+    def _get_executable(self, executable: str = "") -> str:
+        """Find the best octave executable."""
+        return get_octave_executable(executable)
+
+    def _validate_executable(self, executable: str) -> str:
+        """Validate the Octave executable."""
+        cmd = [*shlex.split(executable), "--eval", "disp(version)"]
         try:
             return subprocess.check_output(cmd, text=True).strip()  # noqa: S603
         except subprocess.CalledProcessError as e:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -601,6 +601,27 @@ class TestGetExecutable:
 
 
 # ---------------------------------------------------------------------------
+# executable property
+# ---------------------------------------------------------------------------
+
+
+class TestExecutableProperty:
+    """Tests for OctaveEngine.executable property."""
+
+    def test_plain_executable_returned_unchanged(self, mock_engine):
+        mock_engine._executable = "/usr/bin/octave"
+        assert mock_engine.executable == "/usr/bin/octave"
+
+    def test_xvfb_run_gets_auto_servernum_injected(self, mock_engine):
+        mock_engine._executable = "xvfb-run /usr/bin/octave"
+        assert mock_engine.executable == "xvfb-run --auto-servernum /usr/bin/octave"
+
+    def test_xvfb_run_with_existing_auto_servernum_not_duplicated(self, mock_engine):
+        mock_engine._executable = "xvfb-run --auto-servernum /usr/bin/octave"
+        assert mock_engine.executable.count("--auto-servernum") == 1
+
+
+# ---------------------------------------------------------------------------
 # _validate_executable
 # ---------------------------------------------------------------------------
 
@@ -614,34 +635,6 @@ class TestValidateExecutable:
         ):
             result = mock_engine._validate_executable("/usr/bin/octave")
         assert result == "9.2.0"
-
-    def test_xvfb_run_gets_auto_servernum_injected(self, mock_engine):
-        captured = {}
-
-        def fake_check_output(cmd, **kwargs):
-            captured["cmd"] = cmd
-            return "9.2.0\n"
-
-        with patch("octave_kernel.kernel.subprocess.check_output", fake_check_output):
-            mock_engine._validate_executable("xvfb-run /usr/bin/octave")
-
-        assert captured["cmd"][0] == "xvfb-run"
-        assert captured["cmd"][1] == "--auto-servernum"
-        assert "/usr/bin/octave" in captured["cmd"]
-
-    def test_xvfb_run_with_existing_auto_servernum_not_duplicated(self, mock_engine):
-        captured = {}
-
-        def fake_check_output(cmd, **kwargs):
-            captured["cmd"] = cmd
-            return "9.2.0\n"
-
-        with patch("octave_kernel.kernel.subprocess.check_output", fake_check_output):
-            mock_engine._validate_executable(
-                "xvfb-run --auto-servernum /usr/bin/octave"
-            )
-
-        assert captured["cmd"].count("--auto-servernum") == 1
 
     def test_raises_oserror_on_failure(self, mock_engine):
         import subprocess


### PR DESCRIPTION
## References

Closes #320

## Description

Follow-up to #321. The prior fix injected `--auto-servernum` only in `_validate_executable`, but `_create_repl` used `self.executable` directly — without the flag. On kernel restart, when an Xvfb server was already running, `xvfb-run` would exit with status 1 and the kernel would fail to start.

## Changes

- Convert `executable` to a property that normalises the xvfb-run command by injecting `--auto-servernum` when needed
- Store the raw value in `_executable`; all callers (`_validate_executable`, `_create_repl`, `_get_temp_dir`) automatically get the corrected string
- Simplify `_validate_executable` now that injection is handled by the property
- Move xvfb `--auto-servernum` tests from `TestValidateExecutable` to a new `TestExecutableProperty` class

## Backwards-incompatible changes

None

## Testing

Existing test suite passes (`uv run pytest tests/test_engine.py`). The xvfb injection is now verified through the property tests rather than via `_validate_executable`.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude (claude-sonnet-4-6)