### PR TITLE
ci: use maintainer_tools actions for zizmor, codeql, pre-commit-run, and pre-commit-autoupdate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Analyze (${{ matrix.language }})
-      uses: Calysto/maintainer_tools/codeql@v1
+      uses: Calysto/maintainer_tools/actions/codeql@v1
       with:
         language: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL Advanced"
 
 on:
@@ -23,20 +12,10 @@ jobs:
   analyze:
     if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
-      # required for all workflows
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
       packages: read
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
 
@@ -48,55 +27,13 @@ jobs:
           build-mode: none
         - language: python
           build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162 # v4
       with:
-        languages: ${{ matrix.language }}
+        persist-credentials: false
+    - name: Analyze (${{ matrix.language }})
+      uses: Calysto/maintainer_tools/codeql@v1
+      with:
+        language: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 # v4
-      with:
-        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Analyze (${{ matrix.language }})
-      uses: Calysto/maintainer_tools/actions/codeql@v1
+      uses: calysto/maintainer_tools/actions/codeql@v1
       with:
         language: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -15,25 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: Calysto/maintainer_tools/pre-commit-autoupdate@v1
         with:
           app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-          cache: pip
-      - run: pip install pre-commit
-      - run: pre-commit autoupdate
-      - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          commit-message: 'chore: pre-commit autoupdate'
-          title: 'chore: pre-commit autoupdate'
-          branch: pre-commit-autoupdate
-          labels: maintenance
+          app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: Calysto/maintainer_tools/pre-commit-autoupdate@v1
+      - uses: Calysto/maintainer_tools/actions/pre-commit-autoupdate@v1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: Calysto/maintainer_tools/actions/pre-commit-autoupdate@v1
+      - uses: calysto/maintainer_tools/actions/pre-commit-autoupdate@v1
         with:
           app-id: ${{ vars.APP_ID }}
           app-private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Run pre-commit
-        uses: Calysto/maintainer_tools/pre-commit-run@v1
+        uses: Calysto/maintainer_tools/actions/pre-commit-run@v1
       - name: Run typing check
         run: just typing
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Run pre-commit
-        uses: Calysto/maintainer_tools/actions/pre-commit-run@v1
+        uses: calysto/maintainer_tools/actions/pre-commit-run@v1
       - name: Run typing check
         run: just typing
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - name: Run pre-commit
-        run: just pre-commit --hook-stage=manual
+        uses: Calysto/maintainer_tools/pre-commit-run@v1
       - name: Run typing check
         run: just typing
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run zizmor 🌈
-        uses: Calysto/maintainer_tools/zizmor@v1
+        uses: Calysto/maintainer_tools/actions/zizmor@v1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run zizmor 🌈
-        uses: Calysto/maintainer_tools/actions/zizmor@v1
+        uses: calysto/maintainer_tools/actions/zizmor@v1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   zizmor:
-    name: zizmor latest via Cargo
+    name: zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -18,4 +18,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+        uses: Calysto/maintainer_tools/zizmor@v1

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        actions/*: ref-pin
-        calysto/maintainer_tools/*: ref-pin


### PR DESCRIPTION
## References

https://github.com/Calysto/maintainer_tools/releases/tag/v1.3.0

## Description

Update CI workflows to use the new composite actions from `Calysto/maintainer_tools` v1.3.0, and remove the local zizmor config (the new action ships a bundled fallback).

## Changes

- Replace `zizmorcore/zizmor-action` with `Calysto/maintainer_tools/zizmor@v1` in `zizmor.yml`
- Replace raw `github/codeql-action/init` + `analyze` steps with `Calysto/maintainer_tools/codeql@v1` in `codeql.yml`
- Replace manual token/checkout/pip/pre-commit/create-pr steps with `Calysto/maintainer_tools/pre-commit-autoupdate@v1` in `pre-commit-autoupdate.yml`
- Replace `just pre-commit --hook-stage=manual` with `Calysto/maintainer_tools/pre-commit-run@v1` in the `static` job of `test.yml`
- Delete `.github/zizmor.yml` (the new zizmor action provides a bundled config as fallback)

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (claude-sonnet-4-6)