### PR TITLE
test: skip test_inspect on Windows

### DIFF
--- a/test_octave_kernel.py
+++ b/test_octave_kernel.py
@@ -68,6 +68,10 @@ class OctaveKernelTests(jkt.KernelTests):  # type:ignore[misc]
     code_inspect_sample = "ones"
 
     @unittest.skipIf(sys.platform == "win32", "Test does not work on windows")
+    def test_inspect(self) -> None:
+        super().test_inspect()
+
+    @unittest.skipIf(sys.platform == "win32", "Test does not work on windows")
     def test_doc_does_not_hang(self) -> None:
         """Test that doc command completes without hanging (issue #184)."""
         try:


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

The `test_inspect` test is inherited from `jupyter_kernel_test.KernelTests` and does not work on Windows. This PR overrides it in `OctaveKernelTests` with a `@unittest.skipIf(sys.platform == "win32", ...)` decorator (delegating to `super().test_inspect()`), consistent with how `test_doc_does_not_hang` and `test_open_does_not_hang` are already handled.

## Changes

- Override `test_inspect` in `OctaveKernelTests` to skip on Windows

## Backwards-incompatible changes

None

## Testing

N/A

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude (claude-sonnet-4-6)