### PR TITLE
fix: include runner image version in macOS Octave cache key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/brew-octave-cellar.tar
-        key: macos-brew-octave-${{ env.OCTAVE_VERSION }}
+        key: macos-brew-octave-${{ env.OCTAVE_VERSION }}-image-${{ env.ImageVersion }}
 
     - name: Install Octave from cache (macos)
       if: inputs.install-type == 'macos' && steps.cache-brew-octave.outputs.cache-hit == 'true'


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Fixes a recurring macOS CI failure where Octave crashes with exit code 134 due to a missing `libevent` dylib. The cached `open-mpi` was compiled against `libevent_core-2.1.7.dylib` from the runner image at cache-build time, but when the runner image updated `libevent`, that dylib was no longer present.

## Changes

- Include the runner image version (`$ImageVersion`) in the macOS Octave cache key (`macos-brew-octave-<version>-image-<ImageVersion>`), so the cache is automatically invalidated whenever the runner image changes and pre-installed brew dependency versions may have shifted.

## Backwards-incompatible changes

None

## Testing

The existing stale cache will be abandoned on the next run; a fresh `brew install octave` will build a new cache entry tied to the current image, and subsequent runs will restore a coherent set of libraries.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude (claude-sonnet-4-6)