### PR TITLE
Update macOS version in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,9 @@ jobs:
   test-other-systems:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-15, windows-latest]
         include:
-          - os: macos-latest
+          - os: macos-15
             install-type: macos
           - os: windows-latest
             install-type: windows


### PR DESCRIPTION
## References

Fixes CI failures caused by `macos-latest` migrating to macOS 26 on June 15, 2026, which breaks `brew install octave` (exit code 134).

## Description

Pin the macOS CI runner from `macos-latest` to `macos-15` to restore a working Octave installation. The `macos-latest` label now points to macOS 26, which is incompatible with the current Homebrew Octave formula. This is a temporary workaround until upstream support for macOS 26 is available.

## Changes

- Changed `runs-on: macos-latest` to `runs-on: macos-15` in the CI workflow

## Backwards-incompatible changes

None

## Testing

CI job should pass on the pinned macOS 15 runner.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude (Anthropic)