### PR TITLE
CI: Fix Octave installation on MacOS

### DIFF
--- a/.github/scripts/macos-install-cache.sh
+++ b/.github/scripts/macos-install-cache.sh
@@ -3,7 +3,9 @@ set -eu
 echo "Restoring Octave Cellar from cache archive..."
 tar -xf ~/brew-octave-cellar.tar -C /
 echo "Linking octave..."
-brew link octave
+brew link --overwrite octave
+echo "Reinstalling octave to fix dynamic library links..."
+brew reinstall octave
 # Set Qt plugin path so octave can find the cocoa platform plugin
 QT_PREFIX=$(brew --prefix qtbase 2>/dev/null || echo "/opt/homebrew/opt/qtbase")
 echo "QT_QPA_PLATFORM_PLUGIN_PATH=$QT_PREFIX/share/qt/plugins/platforms" >> "$GITHUB_ENV"

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/brew-octave-cellar.tar
-        key: macos-brew-octave-${{ env.OCTAVE_VERSION }}-image-${{ env.ImageVersion }}
+        key: macos-brew-octave-${{ env.OCTAVE_VERSION }}-${{ runner.image }}-...
 
     - name: Install Octave from cache (macos)
       if: inputs.install-type == 'macos' && steps.cache-brew-octave.outputs.cache-hit == 'true'


### PR DESCRIPTION
## Description

The `test-other-systems` macOS job restores a cached Homebrew Octave Cellar archive (key `macos-brew-octave-11.3.0-image-`) to skip rebuilding Octave on every run. That cache does not pin to a specific runner image version, so when GitHub bumps the bundled `gcc` version in the `macos-15-arm64` runner image, the restored Octave binaries (linked against the old `gcc`'s `libgfortran.5.dylib` via the `current` symlink) no longer resolve, and `octave --version` aborts with a dyld load failure.

## Changes

- After restoring the cached Octave Cellar, run `brew reinstall octave` so Octave is rebuilt/relinked against whichever `gcc` is actually present on the runner image, instead of trusting a stale cached binary's dependency links.
- This trades a bit of cache effectiveness for correctness: the cache still saves the Octave download/build time when the toolchain hasn't moved, but `brew reinstall` self-heals the install whenever it has.

## Backwards-incompatible changes

None

## Testing

CI — verified the `test-other-systems (macos-latest)` job runs `octave --version` and `available_graphics_toolkits` successfully after cache restore + reinstall.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: None