### PR TITLE
CI: use maintainer_tools build action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@ebd3b6c6d32b78607276633a23bdd4481bd23ca8 # v2.18.0
+      - uses: calysto/maintainer_tools/actions/build@v1
 
   publish-docker:
     if: github.event_name != 'schedule' || github.repository == 'Calysto/octave_kernel'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ${{ fromJSON(needs.build.outputs.supported_python_classifiers_json_array) }}
+        python-version: ${{ fromJSON(needs.build.outputs.python-versions) }}
         include:
           - os: ubuntu-22.04
             python-version: '3.11'
@@ -133,14 +133,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      supported_python_classifiers_json_array: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+      python-versions: ${{ steps.build.outputs.python-versions }}
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: calysto/maintainer_tools/actions/base-setup@v1
-      - uses: hynek/build-and-inspect-python-package@ebd3b6c6d32b78607276633a23bdd4481bd23ca8 # v2.18.0
-        id: baipp
+      - uses: calysto/maintainer_tools/actions/build@v1
+        id: build
         with:
           include-free-threaded: "true"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,8 +141,6 @@ jobs:
       - uses: calysto/maintainer_tools/actions/base-setup@v1
       - uses: calysto/maintainer_tools/actions/build@v1
         id: build
-        with:
-          include-free-threaded: "true"
 
   test_sdist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## References

N/A

## Description

Replaces the direct `hynek/build-and-inspect-python-package` usage with the new `calysto/maintainer_tools/actions/build` wrapper action in the test and release workflows, for consistency with other maintainer_tools-managed workflows.

## Changes

- `test.yml`: use `calysto/maintainer_tools/actions/build@v1` in the `build` job; update the `needs.build.outputs` reference from `supported_python_classifiers_json_array` to `python-versions`.
- `release.yml`: use `calysto/maintainer_tools/actions/build@v1` in the `build-package` job.

## Backwards-incompatible changes

None

## Testing

N/A - CI workflow change, verified via `just typing` and `just pre-commit`.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code