### PR TITLE
Widen pexpect close/terminate delay to avoid free-threaded teardown race

### DIFF
--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -615,6 +615,13 @@ class OctaveEngine:
         repl.interrupt = self._interrupt  # type: ignore[method-assign]
         # Remove the default 50ms delay before sending lines.
         repl.child.delaybeforesend = None
+        # ptyprocess's close() sleeps `delayafterclose` (default 0.1s) then
+        # checks isalive() before raising "Could not terminate the child."
+        # On the free-threaded (no-GIL) build, process reaping can lag past
+        # that window even though the termination signal was already sent,
+        # producing a false positive. Give it more headroom.
+        repl.child.delayafterclose = 0.5
+        repl.child.delayafterterminate = 0.5
         return repl
 
     def _interrupt(self, continuation: bool = False, silent: bool = False) -> str:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -522,6 +522,18 @@ class TestCreateRepl:
             repl = mock_engine._create_repl()
         assert repl.child.delaybeforesend is None
 
+    def test_widens_delayafterclose(self, mock_engine):
+        with patch("octave_kernel.kernel.REPLWrapper") as MockRepl:
+            MockRepl.return_value = MagicMock()
+            repl = mock_engine._create_repl()
+        assert repl.child.delayafterclose == 0.5
+
+    def test_widens_delayafterterminate(self, mock_engine):
+        with patch("octave_kernel.kernel.REPLWrapper") as MockRepl:
+            MockRepl.return_value = MagicMock()
+            repl = mock_engine._create_repl()
+        assert repl.child.delayafterterminate == 0.5
+
     def test_appends_octave_cli_options_env_var(self, mock_engine):
         cmd = self._repl_cmd(mock_engine, OCTAVE_CLI_OPTIONS="--no-gui")
         assert "--no-gui" in cmd


### PR DESCRIPTION
## References

<!-- issue numbers -->
Surfaced by oct2py's CI on the `test (3.14t)` matrix leg:
https://github.com/blink1073/oct2py/actions/runs/30259504522/job/89956026163

## Description

On the free-threaded (no-GIL) Python 3.14t build, `OctaveEngine` consumers
occasionally see `pexpect.exceptions.ExceptionPexpect: Could not terminate
the child` raised out of `REPLWrapper.terminate()` during teardown, even
though the Octave subprocess was in fact terminating normally.

Root cause: `ptyprocess.PtyProcess.close()` closes the fd, sleeps
`delayafterclose` (default 0.1s), then checks `isalive()` before raising.
Under the free-threaded build, process reaping/signal delivery appears to
be racier, so `isalive()` can still report `True` immediately after the
termination signal was sent — a false "could not terminate", not an actual
leaked process.

This kernel's own `_cleanup()` (registered via `atexit`) already tolerates
any exception from `repl.terminate()`, so kernel shutdown itself is
unaffected. But any caller that terminates the REPL directly — e.g.
oct2py's `Oct2Py.exit()`/`restart()`, which unregister `_cleanup` from
`atexit` and call `self._engine.repl.terminate()` themselves — sees the
exception propagate.

## Changes

- Widen `delayafterclose`/`delayafterterminate` on the pexpect child to
  0.5s in `OctaveEngine._create_repl()`, giving the kernel more headroom
  before `isalive()` is checked. This is the same spot that already
  removes the default `delaybeforesend` delay, so it benefits every
  `OctaveEngine` consumer rather than requiring each one to reach into
  `repl.child` itself.
- Add regression tests in `tests/test_engine.py::TestCreateRepl` asserting
  both delays are set on the constructed REPL's child.

## Backwards-incompatible changes

None. `delayafterclose`/`delayafterterminate` only affect the tail end of
`close()`'s wait-then-check sequence during teardown; going from 0.1s to
0.5s in the (rare) case where the process is still shutting down does not
change behavior for any caller not currently affected by this race.

## Testing

- `poetry run pytest`: 174 passed.
- `just typing`: no issues.
- `just pre-commit`: all hooks pass.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code