### PR TITLE
ci: drop redundant Test PyPI upload step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,13 +119,6 @@ jobs:
           name: Packages
           path: dist
 
-      - name: Upload package to Test PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: ${{ needs.release.outputs.dry_run == 'true' }}
-          verbose: ${{ needs.release.outputs.dry_run == 'true' }}
-
       - name: Upload package to PyPI
         if: ${{ needs.release.outputs.dry_run != 'true' }}
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0


### PR DESCRIPTION
## References

<!-- issue numbers -->

## Description

Implements item 1 of the [CI/release workflow hardening checklist](https://gist.github.com/blink1073/b2e97409c039be78446a678ad2796f22) (based on [calysto/metakernel#466](https://github.com/Calysto/metakernel/pull/466)): drops the "Upload package to Test PyPI" step from `release.yml`.

Items 2 and 3 of that checklist are already covered in this repo:
- Static package checks: `validate-pyproject` already runs via pre-commit in the `static` job, and `twine check --strict` already runs as part of `hynek/build-and-inspect-python-package` (used by the `build` job on every push/PR).
- Codecov fork-PR fix: already merged in `b2c4686` ("ci: allow codecov uploads on fork PRs targeting Calysto/octave_kernel").

## Changes

- Remove the "Upload package to Test PyPI" step from `release.yml`. It doesn't catch anything the existing static build/package checks don't already catch, and it's one more external service in the critical path of every release.

## Backwards-incompatible changes

None

## Testing

- `just pre-commit`
- `just typing`

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code