### PR TITLE
Standardize justfile targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ just cover                         # tests with coverage report
 ## Code Quality
 
 ```shell
-just pre-commit                    # run all pre-commit hooks
+just lint                          # run all pre-commit hooks
+just lint-all                      # also run manual-stage hooks (markdown-link-check)
 just typing                        # mypy strict type checking
 ```
 

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ default:
     @just --list
 
 install:
-    poetry install --only main,dev,test
+    poetry sync --only main,dev,test
     poetry run pre-commit install
 
 docker-build:
@@ -21,51 +21,48 @@ docker-run:
     docker run -it --rm -p {{PORT}}:8888 calysto/octave-notebook
 
 test *args="":
-    poetry install --only main,test
+    poetry sync --only main,test
     poetry run pytest {{args}}
 
 test-kernel:
-    poetry install --only main,test
+    poetry sync --only main,test
     poetry run python -m octave_kernel install --sys-prefix
     poetry run python -m unittest -v test_octave_kernel.py
     poetry run python -m octave_kernel.check
     poetry run python test_octave_kernel.py
 
 test-notebook:
-    poetry install --only main,test
+    poetry sync --only main,test
     poetry run jupyter execute --kernel_name octave octave_kernel.ipynb
 
 cover *args="":
-    poetry install --only main,coverage
+    poetry sync --only main,coverage
     poetry run pytest --cov=octave_kernel --cov-report=term-missing --cov-report=xml --cov-fail-under=90 {{args}}
     poetry run coverage html
 
 typing:
-    poetry install --only main,typing
+    poetry sync --only main,typing
     poetry run mypy . --install-types --non-interactive
 
 run-notebook:
-    poetry install --only main,test
+    poetry sync --only main,test
     poetry run jupyter notebook octave_kernel.ipynb
 
 test-manual:
-    poetry install --only main,dev
+    poetry sync --only main,dev
     poetry run python -m octave_kernel install --sys-prefix
     poetry run jupyter-console --kernel=octave
 
-lint:
-    poetry install --only main,dev
-    poetry run pre-commit run ruff-format --all-files
-    poetry run pre-commit run ruff-check --all-files
-    poetry run pre-commit run validate-pyproject --all-files
-    poetry run pre-commit run poetry-check --all-files
-
-pre-commit *args="":
-    poetry install --only main,dev
+lint *args="":
+    poetry sync --only main,dev
     poetry run pre-commit run --all-files {{args}}
 
+lint-all *args="":
+    poetry sync --only main,dev
+    poetry run pre-commit run --all-files --hook-stage manual {{args}}
+
 _asv-setup:
-    poetry install --only main,benchmark
+    poetry sync --only main,benchmark
     poetry run asv machine --yes
 
 benchmark *args="": _asv-setup
@@ -75,9 +72,9 @@ benchmark-compare: _asv-setup
     poetry run asv continuous $(git merge-base HEAD origin/main) HEAD --split
 
 docs:
-    poetry install --only main,docs
+    poetry sync --only main,docs
     poetry run mkdocs build
 
 docs-serve:
-    poetry install --only main,docs
+    poetry sync --only main,docs
     poetry run mkdocs serve


### PR DESCRIPTION
## References

None

## Description

The five developer commands now mean the same thing in every Calysto repo: `install`, `test`, `cover`, `typing`, and `lint`.

Two things were confusing before. `lint` ran a hand-picked subset of pre-commit hooks while a separate `pre-commit` recipe ran all of them, so neither name described what it did. Recipes also did not control their own environment, so running one target could leave dependencies in a state the next target did not expect. Each recipe now syncs the exact dependency groups it needs, which makes any order of commands safe.

## Changes

- Renamed the run-all-hooks recipe from `pre-commit` to `lint`
- Added `lint-all` for hooks that only run at the manual stage, such as `markdown-link-check`
- Every recipe syncs the dependency groups it needs before doing its work
- Updated the contributing guide to match

## Backwards-incompatible changes

`just pre-commit` no longer exists. Use `just lint`, or `just lint-all` to include the manual-stage hooks.

## Testing

- `just lint` passes
- `just typing` passes with no issues in 13 source files
- `just test` passes, 174 tests
- Ran `just test` followed by `just lint` to confirm the second command re-syncs its group instead of failing on a pruned environment

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [x] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
