### PR TITLE
Terminate the Octave process when engine startup fails

### DIFF
--- a/octave_kernel/kernel.py
+++ b/octave_kernel/kernel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import contextlib
 import glob
 import json
 import logging
@@ -351,8 +352,18 @@ class OctaveEngine:
         self.line_handler = line_handler
         self._has_startup = False
         self._plot_settings = plot_settings
-        if not defer_startup:
-            self._startup()
+        try:
+            if not defer_startup:
+                self._startup()
+        except BaseException:
+            # _cleanup is not registered yet and __init__ will not return, so
+            # nothing else can reach self.repl.  Without this the Octave
+            # process runs for the life of the interpreter, unreferenced.
+            # A later _startup() (the defer_startup path) is not affected:
+            # by then the caller holds the engine and atexit is armed.
+            with contextlib.suppress(Exception):
+                self.repl.terminate()
+            raise
         atexit.register(self._cleanup)
 
     @property

--- a/poetry.lock
+++ b/poetry.lock
@@ -1436,14 +1436,14 @@ files = [
 
 [[package]]
 name = "metakernel"
-version = "1.0.0"
+version = "1.0.6"
 description = "A Jupyter/IPython Kernel base class in Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
 files = [
-    {file = "metakernel-1.0.0-py3-none-any.whl", hash = "sha256:9f90660ce583baffe0235316f3e1a0abf75bbf60039e811ccbedd68ef612fa44"},
-    {file = "metakernel-1.0.0.tar.gz", hash = "sha256:76f2b8926cbad5a089deb6f727399c4e34e8915af97896a8bb7968ebe02da21c"},
+    {file = "metakernel-1.0.6-py3-none-any.whl", hash = "sha256:98844d70e015890ea3d3a9f8f67e3a799861609f0cace4cec986e1a3d6a7f36e"},
+    {file = "metakernel-1.0.6.tar.gz", hash = "sha256:09f898f50d037f1e69ca180f4238d330989c407f9c424808fc333592e6367883"},
 ]
 
 [package.dependencies]
@@ -2855,4 +2855,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "064e5d94c7680134afe3d099b9b508dc11eb7b7ce870744b6e017d4fc8fafb5b"
+content-hash = "de7c032026e4caaece4a2cb1c88b593ddfb9a085ae088fa57a11dc30511a96c0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ urls = {Homepage = "http://github.com/Calysto/octave_kernel"}
 requires-python = ">=3.11"
 version = "1.1.1.dev0"
 dependencies = [
-    "metakernel >=1.0",
+    "metakernel >=1.0.6",
     "jupyter_client >=8.1.0",
     "ipykernel >=6.22.0",
     "rpds-py (>=2026.5.1)",

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -797,6 +797,60 @@ class TestInterruptExpect:
 
 
 # ---------------------------------------------------------------------------
+# Startup failure
+# ---------------------------------------------------------------------------
+
+
+class TestStartupFailure:
+    """A failed startup must not leave the Octave process running.
+
+    ``__init__`` arms the atexit cleanup only after ``_startup()`` returns, and
+    it never returns an engine when startup raises, so nothing outside
+    ``__init__`` can reach ``self.repl`` to shut it down.
+    """
+
+    def test_repl_is_terminated_when_startup_raises(self):
+        """The spawned Octave process is killed when _startup() fails."""
+        created = []
+        real_create_repl = OctaveEngine._create_repl
+
+        def _capture_repl(engine_self):
+            repl = real_create_repl(engine_self)
+            created.append(repl)
+            return repl
+
+        with (
+            patch.object(OctaveEngine, "_create_repl", _capture_repl),
+            patch.object(
+                OctaveEngine, "_startup", side_effect=RuntimeError("startup failed")
+            ),
+            pytest.raises(RuntimeError, match="startup failed"),
+        ):
+            OctaveEngine()
+
+        assert created, "the repl should have been created before startup ran"
+        child = created[0].child
+        proc = getattr(child, "proc", None)
+        if proc is not None:  # PopenSpawn, used where there is no pty
+            assert proc.wait(timeout=10) is not None, "Octave is still running"
+        else:
+            assert not child.isalive(), "Octave is still running"
+
+    def test_deferred_startup_arms_cleanup(self):
+        """With defer_startup, a later _startup() failure is not a leak.
+
+        The caller holds the engine and atexit is already armed by then, so the
+        guard in __init__ deliberately does not cover that path.
+        """
+        with patch("atexit.register") as mock_register:
+            engine = OctaveEngine(defer_startup=True)
+        try:
+            assert mock_register.call_args_list[-1].args == (engine._cleanup,)
+        finally:
+            engine._cleanup()
+
+
+# ---------------------------------------------------------------------------
 # _cleanup
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## References

Companion to Calysto/metakernel#475, released in metakernel 1.0.6. No issue filed; found while diagnosing an oct2py CI failure on a Windows runner.

## Description

`OctaveEngine.__init__` creates the repl, runs `_startup()`, and only then registers `_cleanup` with atexit. When `_startup()` raises, `__init__` never returns, so the caller has no engine and nothing can reach `self.repl`: the Octave process keeps running for the life of the interpreter.

The `defer_startup` path is deliberately left uncovered. A `_startup()` failure there happens after the caller holds the engine and atexit is already armed, so it is not a leak, and a test pins that down so the omission does not read as an oversight later.

The neighbouring window is upstream: a failure inside `_create_repl()`, which is `REPLWrapper.__init__`, never returns a repl for this code to terminate. metakernel 1.0.6 handles that case itself, and also closes the child's pipes on the `PopenSpawn` path used on Windows, so the floor moves to 1.0.6.

## Changes

- A failed `_startup()` terminates the repl before the error propagates, so the Octave process does not outlive the failed engine.
- Requires metakernel 1.0.6, which fixes the same class of leak inside `REPLWrapper` and stops `terminate()` leaking pipes on Windows.

## Backwards-incompatible changes

None

## Testing

`just test` (176 passed), `just lint` and `just typing`, all clean, against metakernel 1.0.6.

Two new tests. The leak test fails without this change: the Octave process is still alive after the failed startup. The second asserts that the `defer_startup` path still arms the atexit cleanup, which is what makes leaving it unguarded correct.

## AI usage

- [x] Some or all of the content of this PR was generated by AI.
- [ ] The human author has carefully reviewed this PR and run this code.
- **AI tools and models used**: Claude Code (Opus 5)
